### PR TITLE
WIP of OSX instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Surge
 
-This is the synthesizer plug-in Surge which I previously sold as a commercial product as the company [vember audio](http://vemberaudio.se). 
+This is the synthesizer plug-in Surge which I previously sold as a commercial product as the company [vember audio](http://vemberaudio.se).
+
 As I'm too busy with [other](http://bitwig.com) projects and no longer want to put the effort into maintaining it myself across multiple platforms I have decided to give it new life as an open-source project.
 
 It was originally released in 2005, and was one of my first bigger projects. The code could be cleaner, and at parts better explained but its reliable and sounds great. And beware, there might still be a few comments in Swedish.
@@ -50,3 +51,26 @@ premake5 vs2017
 and open the visual studio solution which is generated.
 
 To build the installer open the file installer_win/surge.iss using Inno Setup.
+
+## Building - OSX
+
+Start by grabbing `premake5` from https://premake.github.io . 
+
+Copy `premake5` to `/usr/local/bin/premake5`
+
+Clone the Surge repo by typing 
+
+```
+git clone https://github.com/kurasu/surge.git
+```
+
+After that, get all the submodules referenced by the Surge repo by typing
+
+```
+git submodule update --init --recursive
+```
+
+Now, boot up Xcode and open the project. Let it do the indexing/processing.
+
+Choose `Update to recommended settings" for `surge-au`, `surge-vst2` and `surge-vst3`. Click on `Perform Changes`.
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ It currently only builds on windows, but getting it to build on macOS again & Li
 
 [Releases are available here](https://github.com/kurasu/surge/releases)
 
+Discussion at KVR-Forum [here](https://www.kvraudio.com/forum/viewtopic.php?f=1&t=511922)
+
 ## Preparation
 
 First you need to grab all git submodules (needed to get the VST SDKs)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It currently only builds on windows, but getting it to build on macOS again & Li
 [Releases are available here](https://github.com/kurasu/surge/releases)
 
 Discussion at KVR-Forum [here](https://www.kvraudio.com/forum/viewtopic.php?f=1&t=511922)
+Development Discussion at KVR-Forum [here](https://www.kvraudio.com/forum/viewtopic.php?f=33&t=511921)
 
 ## Preparation
 
@@ -58,7 +59,7 @@ To build the installer open the file installer_win/surge.iss using Inno Setup.
 
 Start by grabbing `premake5` from https://premake.github.io . 
 
-Copy `premake5` to `/usr/local/bin/premake5`
+Copy `premake5` to `/usr/local/bin`
 
 Clone the Surge repo by typing 
 
@@ -66,7 +67,7 @@ Clone the Surge repo by typing
 git clone https://github.com/kurasu/surge.git
 ```
 
-After that, get all the submodules referenced by the Surge repo by typing
+After that, go into the Surge folder and get all the submodules referenced by the Surge repo by typing
 
 ```
 git submodule update --init --recursive
@@ -76,3 +77,4 @@ Now, boot up Xcode and open the project. Let it do the indexing/processing.
 
 Choose `Update to recommended settings" for `surge-au`, `surge-vst2` and `surge-vst3`. Click on `Perform Changes`.
 
+After which "Here there be dragons" - Please, could anyone take this further?


### PR DESCRIPTION
After running these instructions, Xcode says:

`surge-au`  `plugin.h file not found (called by aulayer.h, in file aulayer_presets.cpp:1:)`.

`surge-vst3` `Cannot initialize a parameter of type 'wchar_t *' with an lvalue of type 'Steinberg::Vst::String128' (aka 'Steinberg::Vst::TChar [128]')

`surge-vst2` will succeed - IF you have disabled `Enable Strict Checking of objc_msgSend Calls` by switching it from Yes to No. However, the surge.vst actually does nothing, at least not on my computer. I'm not even able to have it display with Renoise.





however, at least we're closer than ever before to getting Surge running with OSX.