### PR TITLE
Linux build fix for VST2

### DIFF
--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -3,7 +3,7 @@
 
 std::map<int, VSTGUI::CBitmap*> bitmap_registry;
 
-static atomic<int> refCount = 0;
+static std::atomic_int refCount(0);
 
 SurgeBitmaps::SurgeBitmaps()
 {


### PR DESCRIPTION
src/common/gui/SurgeBitmaps.cpp:6:8: error: ‘atomic’ does not name a type; did you mean ‘atoi’?
 static atomic<int> refCount = 0;
        ^~~~~~
        atoi

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>