### PR TITLE
Fix remaining Linux compilation issues

### DIFF
--- a/src/vst3/SurgeVst3Processor.cpp
+++ b/src/vst3/SurgeVst3Processor.cpp
@@ -469,9 +469,9 @@ tresult PLUGIN_API SurgeVst3Processor::getParameterInfo(int32 paramIndex, Parame
 
    info.id = id;
 
-   surgeInstance->getParameterNameW(id, info.title);
-   surgeInstance->getParameterShortNameW(id, info.shortTitle);
-   surgeInstance->getParameterUnitW(id, info.units);
+   surgeInstance->getParameterNameW(id, reinterpret_cast<wchar_t *>(info.title));
+   surgeInstance->getParameterShortNameW(id, reinterpret_cast<wchar_t *>(info.shortTitle));
+   surgeInstance->getParameterUnitW(id, reinterpret_cast<wchar_t *>(info.units));
    info.stepCount = 0; // 1 = toggle,
    info.defaultNormalizedValue = meta.fdefault;
    info.unitId = 0; // meta.clump;
@@ -491,7 +491,7 @@ tresult PLUGIN_API SurgeVst3Processor::getParamStringByValue(ParamID tag,
       return kInvalidArgument;
    }
 
-   surgeInstance->getParameterStringW(tag, valueNormalized, string);
+   surgeInstance->getParameterStringW(tag, valueNormalized, reinterpret_cast<wchar_t *>(string));
 
    return kResultOk;
 }


### PR DESCRIPTION
There is still lot of non-standard cruft that causes warnings (because MSVC++ does not have a good reputation to follow standards at least in the past). These commits should at least fix the compilation errors both for VST2 and VST3.