### PR TITLE
Define soHandle when on Linux

### DIFF
--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -58,6 +58,8 @@ BOOL WINAPI DllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpvReserved)
    return 1;
 }
 } // extern "C"
+#elif __linux__
+namespace VSTGUI { void* soHandle = nullptr; }
 #endif
 
 //-------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Much like hModule is defined when on Windows, it is necessary to define
VSTGUI::soHandle when on Linux.  This keeps loading the plugin from
raising an undefined symbol error.

Fixes: #38