### PR TITLE
Fix undefined symbols

### DIFF
--- a/src/common/gui/PopupEditorDialog.cpp
+++ b/src/common/gui/PopupEditorDialog.cpp
@@ -139,4 +139,14 @@ void spawn_miniedit_text(char* c, int maxchars)
       strncpy(c, me.textdata, maxchars);
    }
 }
+#elif __linux__
+
+#include <stdio.h>
+
+void spawn_miniedit_text(char* c, int maxchars)
+{
+   // FIXME: Implement text edit popup on Linux.
+   fprintf(stderr, "%s: text edit popup is not implemented.\n", __func__);
+}
+
 #endif

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -25,6 +25,10 @@
 
 using namespace std;
 
+#if __linux__
+namespace VSTGUI { void* soHandle = nullptr; }
+#endif
+
 //-------------------------------------------------------------------------------------------------------
 
 AudioEffect* createEffectInstance(audioMasterCallback audioMaster)


### PR DESCRIPTION
With these changes, along with #40, Renoise on Linux was able to successfully recognize the Surge VST2 plugin, though trying to use it still fails.