### PR TITLE
add OBJC_OLD_DISPATCH_PROTOTYPES=1 to macOS

### DIFF
--- a/package-vst3.sh
+++ b/package-vst3.sh
@@ -1,0 +1,34 @@
+#!/bin/bash          
+
+# input config
+RES_SRC_LOCATION="resources"
+PACKAGE_SRC_LOCATION="$RES_SRC_LOCATION/osx-vst2"
+BITMAP_SRC_LOCATION="$RES_SRC_LOCATION/bitmaps"
+BUNDLE_RES_SRC_LOCATION="$RES_SRC_LOCATION/osx-resources"
+EXEC_LOCATION="target/vst2/Release/Surge.dylib"
+
+# output configs
+OUTPUT_DIR=products
+BUNDLE_NAME="Surge.vst"
+BUNDLE_DIR="$OUTPUT_DIR/$BUNDLE_NAME"
+EXEC_TARGET_NAME="Surge"
+
+echo Creating VST Bundle...
+
+# create basic bundle structure
+
+if test -d "$BUNDLE_DIR"; then
+	rm -rf "$BUNDLE_DIR"
+fi
+
+mkdir -p "$BUNDLE_DIR/Contents/MacOS"
+
+# copy executable
+cp "$EXEC_LOCATION" "$BUNDLE_DIR/Contents/MacOS/$EXEC_TARGET_NAME"
+
+# copy Info.plist and PkgInfo
+cp $PACKAGE_SRC_LOCATION/* "$BUNDLE_DIR/Contents/"
+
+# copy bundle resources
+cp -R "$BUNDLE_RES_SRC_LOCATION" "$BUNDLE_DIR/Contents/Resources"
+cp $BITMAP_SRC_LOCATION/* "$BUNDLE_DIR/Contents/Resources/"

--- a/premake5.lua
+++ b/premake5.lua
@@ -43,7 +43,7 @@ if (os.istarget("macosx")) then
 		"SSE_VERSION=3",
 		"MAC_COCOA=1",
 		"COCOA=1",
-                "OBJC_OLD_DISPATCH_PROTOTYPES=1"
+		"OBJC_OLD_DISPATCH_PROTOTYPES=1"
     }
     
     links 

--- a/premake5.lua
+++ b/premake5.lua
@@ -42,7 +42,8 @@ if (os.istarget("macosx")) then
 		"stricmp=strcasecmp",
 		"SSE_VERSION=3",
 		"MAC_COCOA=1",
-		"COCOA=1"
+		"COCOA=1",
+                "OBJC_OLD_DISPATCH_PROTOTYPES=1"
     }
     
     links 

--- a/premake5.lua
+++ b/premake5.lua
@@ -9,8 +9,8 @@ language "C++"
 VSTGUI = "vst3sdk/vstgui4/vstgui/";
 
 defines
-{ 
-  "VSTGUI_ENABLE_DEPRECATED_METHODS=0"
+{
+	"VSTGUI_ENABLE_DEPRECATED_METHODS=0"
 }
 
 floatingpoint "Fast"
@@ -33,7 +33,7 @@ if (os.istarget("macosx")) then
 	vectorextensions "SSE2"
 	
 	defines
-	{ 
+	{
 		"PPC=0",
 		"_MM_ALIGN16=__attribute__((aligned(16)))",
 		"__forceinline=inline",
@@ -50,14 +50,14 @@ if (os.istarget("macosx")) then
 	{
 	}
 
-   defines { "MAC=1", "PPC=0", "WINDOWS=0",  }
-   
-   buildoptions { "-std=c++17", "-stdlib=libc++" }
-   links { "c++" }
-   buildoptions { "-mmacosx-version-min=10.9" }
-   linkoptions { "-mmacosx-version-min=10.9" }
+	defines { "MAC=1", "PPC=0", "WINDOWS=0",  }
 
-   platforms { "x64" }
+	buildoptions { "-std=c++17", "-stdlib=libc++" }
+	links { "c++" }
+	buildoptions { "-mmacosx-version-min=10.9" }
+	linkoptions { "-mmacosx-version-min=10.9" }
+
+	platforms { "x64" }
 
 elseif (os.istarget("linux")) then
 
@@ -68,32 +68,32 @@ elseif (os.istarget("linux")) then
 	{ 
 		"_MM_ALIGN16=__attribute__((aligned(16)))",
 		"__forceinline=inline",
-        		"forceinline=inline",
+		"forceinline=inline",
 		"_aligned_malloc(x,a)=malloc(x)",
 		"_aligned_free(x)=free(x)",
 		"stricmp=strcasecmp",
 		"SSE_VERSION=3",
-                "__cdecl="
-        }
-    
-    links 
+		"__cdecl="
+	}
+
+	links
 	{
 	}
 
-   defines { "WINDOWS=0" }
-   
-   buildoptions { "-std=c++17" }
-   links { }
-   buildoptions {  }
-   linkoptions {  }
+	defines { "WINDOWS=0" }
 
-   platforms { "x64" }
+	buildoptions { "-std=c++17" }
+	links { }
+	buildoptions {  }
+	linkoptions {  }
+
+	platforms { "x64" }
 
 elseif (os.istarget("windows")) then
 
-   toolset "v141"
-   defines 
-   { 
+	toolset "v141"
+	defines
+	{
 		"WINDOWS=1",
 		"WIN32", 
 		"_WINDOWS", 
@@ -106,34 +106,35 @@ elseif (os.istarget("windows")) then
 	}
 
 	nuget { "libpng-msvc-x64:1.6.33.8807" }
-   
-   characterset "MBCS"
-   buildoptions { "/MP" }
-   
-   includedirs {
-      "libs/wtl"
-    }
+
+	characterset "MBCS"
+	buildoptions { "/MP" }
+
+	includedirs {
+		"libs/wtl"
+	}
 	
-   flags { "StaticRuntime", "NoMinimalRebuild" }
+	flags { "StaticRuntime", "NoMinimalRebuild" }
 
-   platforms { "x64" }
+	platforms { "x64" }
 
-   configuration {}
+	configuration {}
 end
 
 includedirs {
-    "libs/xml",
-    "src/common/vt_dsp",
-    "src/common/thread",
-    "vst3sdk/vstgui4",
+	"libs/xml",
+	"src/common/vt_dsp",
+	"src/common/thread",
+	"vst3sdk/vstgui4",
+	"vst3sdk",
 	"libs/"
-}
+	}
 
 -- PLUGIN COMMON --
 
 function plugincommon()
 
-    targetprefix ""
+	targetprefix ""
 	targetname "Surge"
 
 	files {
@@ -143,16 +144,16 @@ function plugincommon()
 		"libs/xml/tinyxml.cpp",
 		"libs/xml/tinyxmlerror.cpp",
 		"libs/xml/tinyxmlparser.cpp",
-        "libs/filesystem/filesystem.cpp",
+		"libs/filesystem/filesystem.cpp",
 		"src/common/vt_dsp/*.cpp",
 		"src/common/thread/*.cpp",
 		"vst3sdk/pluginterfaces/base/*.cpp",
 		}
 
 	includedirs {
-	   "src/common",
-	   "src/common/dsp",
-	   "src/common/gui",
+		"src/common",
+		"src/common/dsp",
+		"src/common/gui",
 	}
 
 	if (os.istarget("macosx")) then
@@ -164,11 +165,11 @@ function plugincommon()
 			"-Wno-unused-variable"
 		}
 
-        sysincludedirs {
-            "src/**",
-            "libs/**",
-            "vst3sdk/vstgui4",
-        }
+		sysincludedirs {
+			"src/**",
+			"libs/**",
+			"vst3sdk/vstgui4",
+		}
 
 		files
 		{
@@ -191,7 +192,7 @@ function plugincommon()
 			"src/mac"
 		}
 
-	   links { 
+		links { 
 			"Accelerate.framework",
 			"ApplicationServices.framework",
 			"AudioUnit.framework",
@@ -212,8 +213,8 @@ function plugincommon()
 		
 		buildoptions {
 			"-Wno-unused-variable",
-                        "`pkg-config gtkmm-3.0 --cflags`",
-                        "-std=c++14"
+			"`pkg-config gtkmm-3.0 --cflags`",
+			"-std=c++14"
 		}
 
 		files
@@ -239,13 +240,12 @@ function plugincommon()
 
 	   links { 
 			"pthread",
-                        "stdc++fs"
-           
+			"stdc++fs"
 		}
 
-           linkoptions {
-                        "`pkg-config gtkmm-3.0 --libs`",
-           }
+		linkoptions {
+			"`pkg-config gtkmm-3.0 --libs`",
+		}
 	elseif (os.istarget("windows")) then
 
 		pchheader "precompiled.h"
@@ -291,61 +291,60 @@ local VST24SDK = os.getenv("VST2SDK_DIR")
 
 if VST24SDK then
 
-    project "surge-vst2"
-    kind "SharedLib"
-    uuid "007990D5-2B46-481D-B38C-D83037CDF54B"
+	project "surge-vst2"
+	kind "SharedLib"
+	uuid "007990D5-2B46-481D-B38C-D83037CDF54B"
 
-    defines
-    {
-        "TARGET_VST2=1",
-    }
+	defines
+	{
+		"TARGET_VST2=1",
+	}
 
-    plugincommon()
+	plugincommon()
 
-    files {
-        "src/vst2/**.cpp",
-        "src/vst2/**.h",
-        VST24SDK .. "/public.sdk/source/vst2.x/**.cpp",
-        "vst3sdk/public.sdk/source/vst2.x/**.cpp",
-        VSTGUI .. "plugin-bindings/aeffguieditor.cpp",
-        }
+	files {
+		"src/vst2/**.cpp",
+		"src/vst2/**.h",
+		VST24SDK .. "/public.sdk/source/vst2.x/**.cpp",
+		"vst3sdk/public.sdk/source/vst2.x/**.cpp",
+		VSTGUI .. "plugin-bindings/aeffguieditor.cpp",
+	}
 
-    excludes {
-        VSTGUI .. "plugguieditor.cpp",
-    }
+	excludes {
+		VSTGUI .. "plugguieditor.cpp",
+	}
 
-    includedirs {
-       "src/vst2",
-       VST24SDK,
-       "vst3sdk"
-    }
+	includedirs {
+		"src/vst2",
+		VST24SDK,
+		"vst3sdk"
+	}
 
-    configuration { "Debug" }
-    targetdir "target/vst2/Debug"
-    targetsuffix "-Debug"
+	configuration { "Debug" }
+	targetdir "target/vst2/Debug"
+	targetsuffix "-Debug"
 
-    configuration { "Release" }
-    targetdir "target/vst2/Release"
+	configuration { "Release" }
+	targetdir "target/vst2/Release"
 
-    configuration {}
+	configuration {}
 
+	if (os.istarget("macosx")) then
 
-    if (os.istarget("macosx")) then
+		targetname "Surge"
+		targetprefix ""
+		postbuildcommands { "./package-vst.sh" }
 
-        targetname "Surge"
-        targetprefix ""
-        postbuildcommands { "./package-vst.sh" }
+		files
+		{
+		"libs/vst/*.mm"
+		}
 
-        files
-        {
-            "libs/vst/*.mm"
-        }
+	elseif (os.istarget("windows")) then
 
-    elseif (os.istarget("windows")) then
+		linkoptions { "/DEF:resources\\windows-vst2\\surge.def" }
 
-        linkoptions { "/DEF:resources\\windows-vst2\\surge.def" }
-
-    end
+	end
 end
 
 -- VST3 PLUGIN --
@@ -363,32 +362,32 @@ defines
 plugincommon()
 
 files {
-    "src/vst3/**.cpp",
-    "src/vst3/**.h",
-    "vst3sdk/*.cpp",
-    "vst3sdk/base/source/*.cpp",
-    "vst3sdk/base/thread/source/*.cpp",
-    "vst3sdk/public.sdk/source/common/*.cpp",
-    "vst3sdk/public.sdk/source/main/pluginfactoryvst3.cpp",
-    "vst3sdk/public.sdk/source/vst/vstguieditor.cpp",
-    "vst3sdk/public.sdk/source/vst/vstinitiids.cpp",
-    "vst3sdk/public.sdk/source/vst/vstnoteexpressiontypes.cpp",
-    "vst3sdk/public.sdk/source/vst/vstsinglecomponenteffect.cpp",
-    "vst3sdk/public.sdk/source/vst/vstaudioeffect.cpp",
-    "vst3sdk/public.sdk/source/vst/vstcomponent.cpp",
-    "vst3sdk/public.sdk/source/vst/vstsinglecomponenteffect.cpp",
-    "vst3sdk/public.sdk/source/vst/vstcomponentbase.cpp",
-    "vst3sdk/public.sdk/source/vst/vstbus.cpp",
-    "vst3sdk/public.sdk/source/vst/vstparameters.cpp",
-    }
+	"src/vst3/**.cpp",
+	"src/vst3/**.h",
+	"vst3sdk/*.cpp",
+	"vst3sdk/base/source/*.cpp",
+	"vst3sdk/base/thread/source/*.cpp",
+	"vst3sdk/public.sdk/source/common/*.cpp",
+	"vst3sdk/public.sdk/source/main/pluginfactoryvst3.cpp",
+	"vst3sdk/public.sdk/source/vst/vstguieditor.cpp",
+	"vst3sdk/public.sdk/source/vst/vstinitiids.cpp",
+	"vst3sdk/public.sdk/source/vst/vstnoteexpressiontypes.cpp",
+	"vst3sdk/public.sdk/source/vst/vstsinglecomponenteffect.cpp",
+	"vst3sdk/public.sdk/source/vst/vstaudioeffect.cpp",
+	"vst3sdk/public.sdk/source/vst/vstcomponent.cpp",
+	"vst3sdk/public.sdk/source/vst/vstsinglecomponenteffect.cpp",
+	"vst3sdk/public.sdk/source/vst/vstcomponentbase.cpp",
+	"vst3sdk/public.sdk/source/vst/vstbus.cpp",
+	"vst3sdk/public.sdk/source/vst/vstparameters.cpp",
+	}
 
 excludes {
-    VSTGUI .. "aeffguieditor.cpp",
+	VSTGUI .. "aeffguieditor.cpp",
 }
 
 includedirs {
-   "src/vst3",
-   "vst3sdk"
+	"src/vst3",
+	"vst3sdk"
 }
 
 configuration { "Debug" }
@@ -402,25 +401,25 @@ configuration {}
 
 if (os.istarget("macosx")) then
 
-    postbuildcommands { "./package-vst3.sh" }
-    
-    files
-    {
+	postbuildcommands { "./package-vst3.sh" }
+
+	files
+	{
 		"vst3sdk/public.sdk/source/main/macmain.cpp",
-       "vst3sdk/*.mm"
-    }
+		"vst3sdk/*.mm"
+	}
 	
 elseif (os.istarget("windows")) then
 
-    linkoptions { "/DEF:resources\\windows-vst3\\surge.def" }
+	linkoptions { "/DEF:resources\\windows-vst3\\surge.def" }
 	
 	files
 	{
 		"vst3sdk/public.sdk/source/main/dllmain.cpp",
 	}
 	
-    flags { "NoImportLib" }
-    
+	flags { "NoImportLib" }
+
 end
 
 -- AUDIO UNIT PLUGIN --
@@ -435,26 +434,27 @@ if (os.istarget("macosx")) then
 	
 	configuration { "Debug" }
 	targetdir "target/au/Debug"
-    targetsuffix "-Debug"
+	targetsuffix "-Debug"
 
 	configuration { "Release" }
 	targetdir "target/au/Release"
 
 	configuration {}
 	
-	defines 
-   	{
+	defines
+	{
 		"TARGET_AUDIOUNIT=1",
 		"TARGET_AU=1",
 		"PLUGGUI=1",
 	}
 	
-	links 
-	{ 
+	links
+	{
 		"AudioToolbox.framework",
+		"AudioUnit.framework",		
 	}
 
-	files 
+	files
 	{
 		"src/au/**.cpp",
 		"src/au/**.h",
@@ -471,7 +471,7 @@ if (os.istarget("macosx")) then
 		"libs/AudioUnits/PublicUtility/CASpectralProcessor.cpp",
 	}
 
-	includedirs 
+	includedirs
 	{
  	  	"src/au",
 		"libs/",
@@ -479,7 +479,7 @@ if (os.istarget("macosx")) then
 		"libs/AudioUnits/PublicUtility",
 	}
 	
-	excludes 
+	excludes
 	{
 		VSTGUI .. "winfileselector.cpp",
 	}


### PR DESCRIPTION
as per discussion on https://github.com/kurasu/surge/issues/49#issuecomment-445348253
this is needed to evade the first fail-error in building this on OSX
```
 in Xcode 10 / macOS 10.14, the default prototype of objc_msgSendSuper has 
changed from the 3 args to a no arg type.
```

thanks for the assist, @baconpaul!