### PR TITLE
add OBJC_OLD_DISPATCH_PROTOTYPES=1

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -42,7 +42,8 @@ if (os.istarget("macosx")) then
 		"stricmp=strcasecmp",
 		"SSE_VERSION=3",
 		"MAC_COCOA=1",
-		"COCOA=1"
+		"COCOA=1",
+		"OBJC_OLD_DISPATCH_PROTOTYPES=1"
     }
     
     links 


### PR DESCRIPTION
as per discussion on https://github.com/kurasu/surge/issues/49#issuecomment-445348253
this is needed to evade the first fail-error in building this on OSX

```
 in Xcode 10 / macOS 10.14, the default prototype of objc_msgSendSuper has 
changed from the 3 args to a no arg type.
```

thanks for the assist, @baconpaul!