### PR TITLE
README.md: References (Links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ It currently only builds on windows, but getting it to build on macOS again & Li
 
 [Releases are available here](https://github.com/kurasu/surge/releases)
 
-Discussion at KVR-Forum [here](https://www.kvraudio.com/forum/viewtopic.php?f=1&t=511922)
-Development Discussion at KVR-Forum [here](https://www.kvraudio.com/forum/viewtopic.php?f=33&t=511921)
-
 ## Preparation
 
 First you need to grab all git submodules (needed to get the VST3 SDK)
@@ -130,3 +127,9 @@ Then restart logic. If everything works and starts up again you can delete the c
 ## Building - VST2
 
 If you want to build VST2 versions of the plug-in, set the environment variable VST2SDK_DIR to the location of the SDK prior to building.
+
+## References
+
+ * Discussion at KVR-Forum [here](https://www.kvraudio.com/forum/viewtopic.php?f=1&t=511922)
+ * Development Discussion at KVR-Forum [here](https://www.kvraudio.com/forum/viewtopic.php?f=33&t=511921)
+ * IRC channel #surgesynth @ irc.freenode.net


### PR DESCRIPTION
Yanked the IRC channel from #40 (seems like `README.md` was the only conflict on that PR

and moved the KVR-Forum discussion links to the same place.