### PR TITLE
premake: Define VST2 boilerplate cpp-files explictly

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -311,7 +311,8 @@ if VST24SDK then
         VST24SDK .. "/public.sdk/source/vst2.x/audioeffect.cpp",
         VST24SDK .. "/public.sdk/source/vst2.x/audioeffectx.cpp",
         VST24SDK .. "/public.sdk/source/vst2.x/vstplugmain.cpp",
-        "vst3sdk/public.sdk/source/vst2.x/**.cpp",
+--      "vst3sdk/public.sdk/source/vst/vst2wrapper/vst2wrapper.cpp",
+--      "vst3sdk/public.sdk/source/vst/vst2wrapper/vst2wrapper.sdk.cpp",
         VSTGUI .. "plugin-bindings/aeffguieditor.cpp",
         }
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -308,7 +308,9 @@ if VST24SDK then
     files {
         "src/vst2/**.cpp",
         "src/vst2/**.h",
-        VST24SDK .. "/public.sdk/source/vst2.x/**.cpp",
+        VST24SDK .. "/public.sdk/source/vst2.x/audioeffect.cpp",
+        VST24SDK .. "/public.sdk/source/vst2.x/audioeffectx.cpp",
+        VST24SDK .. "/public.sdk/source/vst2.x/vstplugmain.cpp",
         "vst3sdk/public.sdk/source/vst2.x/**.cpp",
         VSTGUI .. "plugin-bindings/aeffguieditor.cpp",
         }

--- a/premake5.lua
+++ b/premake5.lua
@@ -493,3 +493,39 @@ if (os.istarget("macosx")) then
 	postbuildcommands { "./package-au.sh" }
 	
 end
+
+if (os.istarget("linux")) then
+    project "surge-app"
+    kind "WindowedApp"
+
+    defines
+    {
+        "TARGET_APP=1"
+    }
+
+    plugincommon()
+
+    files {
+        "src/app/main.cpp",
+        "src/app/PluginLayer.cpp",
+        VSTGUI .. "plugin-bindings/plugguieditor.cpp",
+    }
+
+    includedirs {
+        "src/app"
+    }
+
+    links {
+        "dl",
+        "freetype",
+        "fontconfig",
+        "X11",
+    }
+
+    configuration { "Debug" }
+    targetdir "target/app/Debug"
+    targetsuffix "-Debug"
+
+    configuration { "Release" }
+    targetdir "target/app/Release"
+end

--- a/src/app/PluginLayer.cpp
+++ b/src/app/PluginLayer.cpp
@@ -1,0 +1,11 @@
+#include "PluginLayer.h"
+#include "globals.h"
+#include "SurgeSynthesizer.h"
+
+void PluginLayer::updateDisplay()
+{
+}
+
+void PluginLayer::sendParameterAutomation(long index, float value)
+{
+}

--- a/src/app/PluginLayer.h
+++ b/src/app/PluginLayer.h
@@ -1,0 +1,8 @@
+#include "SurgeSynthesizer.h"
+
+class PluginLayer
+{
+public:
+   void updateDisplay();
+   void sendParameterAutomation(long index, float value);
+};

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,0 +1,11 @@
+#include "globals.h"
+#include "CpuArchitecture.h"
+#include "SurgeSynthesizer.h"
+#include <float.h>
+
+namespace VSTGUI { void* soHandle = nullptr; }
+
+int main(int argc, char **argv)
+{
+   return 0;
+}

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -130,9 +130,9 @@ SurgeStorage::SurgeStorage()
    userDataPath = "~/Documents/Surge";
 
 #elif __linux__
-   
-   printf("Implement me, probably\n");
-   
+
+   userDataPath = "~/Documents/Surge";
+
 #else
 
    PWSTR localAppData;

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -16,6 +16,9 @@
 #elif TARGET_VST3
 #include "SurgeVst3Processor.h"
 #include "vstgui/plugin-bindings/plugguieditor.h"
+#elif TARGET_APP
+#include "PluginLayer.h"
+#include "vstgui/plugin-bindings/plugguieditor.h"
 #else
 #include "Vst2PluginInstance.h"
 #include "vstgui/plugin-bindings/aeffguieditor.h"
@@ -676,6 +679,8 @@ void SurgeSynthesizer::sendParameterAutomation(long index, float value)
       //getParent()->ParameterUpdate(externalparam);
 #elif TARGET_VST3
       getParent()->setParameterAutomated(externalparam, value);
+#elif TARGET_APP
+      getParent()->sendParameterAutomation(externalparam, value);
 #else
       getParent()->setParameterAutomated(externalparam, value);
 #endif

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -21,9 +21,11 @@ typedef aulayer PluginLayer;
 #elif TARGET_VST3
 class SurgeVst3Processor;
 typedef SurgeVst3Processor PluginLayer;
-#else
+#elif TARGET_VST2
 class Vst2PluginInstance;
 using PluginLayer = Vst2PluginInstance;
+#else
+class PluginLayer;
 #endif
 
 class SurgeSynthesizer : public AbstractSynthesizer

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -12,9 +12,12 @@ typedef PluginGUIEditor EditorType;
 #elif TARGET_VST3
 #include "public.sdk/source/vst/vstguieditor.h"
 typedef Steinberg::Vst::VSTGUIEditor EditorType;
-#else
+#elif TARGET_VST2
 #include <vstgui/plugin-bindings/aeffguieditor.h>
 typedef AEffGUIEditor EditorType;
+#else
+#include <vstgui/plugin-bindings/plugguieditor.h>
+typedef PluginGUIEditor EditorType;
 #endif
 
 #include "SurgeStorage.h"


### PR DESCRIPTION
If the boilerplate cpp-files are not enumerated explicitly in premake5.lua,
and if any of them is missing, the plugin will compile without errors but
obviously won't load.

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>