### PR TITLE
[WiP] Include configuration in bundle

### DIFF
--- a/libs/filesystem/filesystem.cpp
+++ b/libs/filesystem/filesystem.cpp
@@ -12,53 +12,67 @@
 #include "filesystem.h"
 
 namespace std::experimental::filesystem {
-        path::path():
-        path("")
-        {}
-        
-        path::path(std::string filePath):
-        p(filePath)
-        {}
-        
-        path::operator std::string() {
-            return p;
-        }
-        
-        void path::append(std::string s) {
-            p.append("/");
-            p.append(s);
-        }
-        
-        const char* path::c_str() {
-            return p.c_str();
-        }
-        
-        std::string path::generic_string() {
-            return p;
-        }
-        
-        path path::filename() {
-            auto idx = this->p.find_last_of("/");
-            path p(this->p.substr(idx+1));
-            return p;
-        }
-        
-        std::string path::extension() {
-            auto idx = this->p.find_last_of(".");
-            return p.substr(idx);
-        }
+    // path class:
+    path::path():
+    path("")
+    {}
     
-        file::file(std::string filePath):
-        p(filePath)
-        {}
-        
-        file::operator class path() {
-            return p;
-        }
-        
-        path file::path() {
-            return p;
-        }
+    path::path(std::string filePath):
+    p(filePath)
+    {}
+    
+    path::operator std::string() {
+        return p;
+    }
+    
+    void path::append(std::string s) {
+        p.append("/");
+        p.append(s);
+    }
+    
+    const char* path::c_str() {
+        return p.c_str();
+    }
+    
+    std::string path::generic_string() const {
+        return p;
+    }
+    
+    path path::filename() {
+        auto idx = this->p.find_last_of("/");
+        path p(this->p.substr(idx+1));
+        return p;
+    }
+    
+    std::string path::extension() {
+        auto idx = this->p.find_last_of(".");
+        return p.substr(idx);
+    }
+    // emd path class
+
+    // file class:
+    file::file(std::string filePath):
+    p(filePath)
+    {}
+    
+    file::operator class path() {
+        return p;
+    }
+    
+    path file::path() const {
+        return p;
+    }
+    // end file class
+    
+    // directory_entry class:
+    directory_entry::directory_entry(class path p):
+    p(p)
+    {}
+    
+    path directory_entry::path() const {
+        return p;
+    }
+    // end directory_entry
     
     bool exists(path p) {
         FILE *file;
@@ -107,9 +121,13 @@ namespace std::experimental::filesystem {
         
         // this needs to return the full path not just the relative path
         while ((dirp = readdir(dp)) != NULL) {
-          path newp = p;
-          newp.append( dirp->d_name );
-          file res( newp.c_str() );
+          string fname(dirp->d_name);
+            // Skip . and .. : https://github.com/kurasu/surge/issues/77
+          if (fname.compare(".") == 0 || fname.compare("..") == 0) {
+              continue;
+          }
+            
+          file res(p.generic_string() + '/' + fname);
 
           files.push_back(res);
         }
@@ -117,6 +135,65 @@ namespace std::experimental::filesystem {
         closedir(dp);
         
         return files;
+    }
+    
+    std::vector<directory_entry> recursive_directory_iterator(const path& src) {
+        std::vector<directory_entry> entries;
+        for(const auto& entry : directory_iterator(src)) {
+            const auto& p = entry.path();
+            directory_entry e(p);
+            entries.emplace_back(e);
+            if (is_directory(p)) {
+                std::vector<directory_entry> subdir = recursive_directory_iterator(p);
+                for(const auto& subdirEntry : subdir) {
+                    entries.emplace_back(subdirEntry);
+                }
+            }
+        }
+        return entries;
+    }
+    
+    path relative(const path& p, const path& root) {
+        return path(p.generic_string().substr(root.generic_string().length()));
+    }
+    
+    void copy(const path& src, const path& dst, const copy_options options) {
+        std::ifstream in(src.generic_string());
+        std::ofstream out(dst.generic_string());
+        out << in.rdbuf();
+    }
+    
+    void copy_recursive(const path& src, const path& target, const std::function<bool(path)>& predicate) noexcept
+    {
+        try
+        {
+            for (const auto& dirEntry : recursive_directory_iterator(src))
+            {
+                const auto& p = dirEntry.path();
+                if (predicate(p))
+                {
+                    // Create path in target, if not existing.
+                    const auto relativeSrc = relative(p, src);
+                    auto targetStr = target.generic_string() + '/' + relativeSrc.generic_string();
+                    path targetPath(targetStr);
+                    if (is_directory(p)) {
+                        create_directories(targetPath);
+                    } else {
+                        // Copy to the targetParentPath which we just created.
+                        copy(p, targetPath, copy_options::overwrite_existing);
+                    }
+                }
+            }
+        }
+        catch (std::exception& e)
+        {
+            //        std::cout << e.what();
+        }
+    }
+    
+    void copy_recursive(const path& src, const path& target) noexcept
+    {
+        copy_recursive(src, target, [](path p) { return true; });
     }
 }
 

--- a/libs/filesystem/filesystem.h
+++ b/libs/filesystem/filesystem.h
@@ -8,6 +8,8 @@
 #ifndef Filesystem_h
 #define Filesystem_h
 
+#include <functional>
+
 #ifdef __APPLE__
 #include "TargetConditionals.h"
 #ifdef TARGET_OS_MAC
@@ -17,6 +19,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <fstream>
 
 namespace std::experimental::filesystem {
     class path {
@@ -33,7 +36,7 @@ namespace std::experimental::filesystem {
         
         const char* c_str();
         
-        std::string generic_string();
+        std::string generic_string() const;
         
         path filename();
         
@@ -48,7 +51,16 @@ namespace std::experimental::filesystem {
         
         operator path();
         
-        path path();
+        path path() const;
+    };
+    
+    class directory_entry {
+    public:
+        path p;
+
+        directory_entry(path p);
+
+        path path() const;
     };
     
     bool exists(path p);
@@ -58,6 +70,21 @@ namespace std::experimental::filesystem {
     bool is_directory(path p);
     
     std::vector<file> directory_iterator(path p);
+    
+    std::vector<directory_entry> recursive_directory_iterator(const path& src);
+    
+    path relative(const path& p, const path& root);
+    
+    enum copy_options {
+        overwrite_existing = 1
+    };
+    
+    void copy(const path& src, const path& dst, const copy_options options);
+
+    // Exras:
+    void copy_recursive(const path& src, const path& target, const std::function<bool(path)>& predicate) noexcept;
+
+    void copy_recursive(const path& src, const path& target) noexcept;
 }
 
 #endif

--- a/package-au.sh
+++ b/package-au.sh
@@ -6,7 +6,7 @@ PACKAGE_SRC_LOCATION="$RES_SRC_LOCATION/osx-au"
 BITMAP_SRC_LOCATION="$RES_SRC_LOCATION/bitmaps"
 BUNDLE_RES_SRC_LOCATION="$RES_SRC_LOCATION/osx-resources"
 EXEC_LOCATION="target/au/Release/Surge.dylib"
-EXEC_LOCATION="target/au/Debug/Surge-Debug.dylib"
+#EXEC_LOCATION="target/au/Debug/Surge-Debug.dylib"
 
 # output configs
 OUTPUT_DIR=products
@@ -33,5 +33,5 @@ cp $PACKAGE_SRC_LOCATION/* "$BUNDLE_DIR/Contents/"
 # copy bundle resources
 cp -R "$BUNDLE_RES_SRC_LOCATION" "$BUNDLE_DIR/Contents/Resources"
 cp $BITMAP_SRC_LOCATION/* "$BUNDLE_DIR/Contents/Resources/"
-cp resources/data/configuration.xml "$BUNDLE_DIR/Contents/Resources"
-
+mkdir -f
+cp -rf resources/data "$BUNDLE_DIR/Contents/Data"

--- a/package-au.sh
+++ b/package-au.sh
@@ -6,6 +6,7 @@ PACKAGE_SRC_LOCATION="$RES_SRC_LOCATION/osx-au"
 BITMAP_SRC_LOCATION="$RES_SRC_LOCATION/bitmaps"
 BUNDLE_RES_SRC_LOCATION="$RES_SRC_LOCATION/osx-resources"
 EXEC_LOCATION="target/au/Release/Surge.dylib"
+EXEC_LOCATION="target/au/Debug/Surge-Debug.dylib"
 
 # output configs
 OUTPUT_DIR=products
@@ -32,3 +33,5 @@ cp $PACKAGE_SRC_LOCATION/* "$BUNDLE_DIR/Contents/"
 # copy bundle resources
 cp -R "$BUNDLE_RES_SRC_LOCATION" "$BUNDLE_DIR/Contents/Resources"
 cp $BITMAP_SRC_LOCATION/* "$BUNDLE_DIR/Contents/Resources/"
+cp resources/data/configuration.xml "$BUNDLE_DIR/Contents/Resources"
+

--- a/package-vst.sh
+++ b/package-vst.sh
@@ -32,3 +32,5 @@ cp $PACKAGE_SRC_LOCATION/* "$BUNDLE_DIR/Contents/"
 # copy bundle resources
 cp -R "$BUNDLE_RES_SRC_LOCATION" "$BUNDLE_DIR/Contents/Resources"
 cp $BITMAP_SRC_LOCATION/* "$BUNDLE_DIR/Contents/Resources/"
+cp resources/data/configuration.xml "$BUNDLE_DIR/Contents/Resources"
+

--- a/package-vst.sh
+++ b/package-vst.sh
@@ -6,6 +6,7 @@ PACKAGE_SRC_LOCATION="$RES_SRC_LOCATION/osx-vst2"
 BITMAP_SRC_LOCATION="$RES_SRC_LOCATION/bitmaps"
 BUNDLE_RES_SRC_LOCATION="$RES_SRC_LOCATION/osx-resources"
 EXEC_LOCATION="target/vst2/Release/Surge.dylib"
+#EXEC_LOCATION="target/vst2/Debug/Surge-Debug.dylib"
 
 # output configs
 OUTPUT_DIR=products
@@ -32,5 +33,6 @@ cp $PACKAGE_SRC_LOCATION/* "$BUNDLE_DIR/Contents/"
 # copy bundle resources
 cp -R "$BUNDLE_RES_SRC_LOCATION" "$BUNDLE_DIR/Contents/Resources"
 cp $BITMAP_SRC_LOCATION/* "$BUNDLE_DIR/Contents/Resources/"
-cp resources/data/configuration.xml "$BUNDLE_DIR/Contents/Resources"
+mkdir -f 
+cp -rf resources/data "$BUNDLE_DIR/Contents/Data"
 

--- a/package-vst3.sh
+++ b/package-vst3.sh
@@ -32,3 +32,5 @@ cp $PACKAGE_SRC_LOCATION/* "$BUNDLE_DIR/Contents/"
 # copy bundle resources
 cp -R "$BUNDLE_RES_SRC_LOCATION" "$BUNDLE_DIR/Contents/Resources"
 cp $BITMAP_SRC_LOCATION/* "$BUNDLE_DIR/Contents/Resources/"
+cp resources/data/configuration.xml "$BUNDLE_DIR/Contents/Resources"
+

--- a/package-vst3.sh
+++ b/package-vst3.sh
@@ -32,5 +32,6 @@ cp $PACKAGE_SRC_LOCATION/* "$BUNDLE_DIR/Contents/"
 # copy bundle resources
 cp -R "$BUNDLE_RES_SRC_LOCATION" "$BUNDLE_DIR/Contents/Resources"
 cp $BITMAP_SRC_LOCATION/* "$BUNDLE_DIR/Contents/Resources/"
-cp resources/data/configuration.xml "$BUNDLE_DIR/Contents/Resources"
+mkdir -f 
+cp -rf resources/data "$BUNDLE_DIR/Contents/Data"
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -460,6 +460,7 @@ if (os.istarget("macosx")) then
 	files 
 	{
 		"src/au/**.cpp",
+                "src/au/**.mm",        
 		"src/au/**.h",
 		"libs/AudioUnits/AUPublic/**.cpp",
 		"libs/AudioUnits/AUPublic/**.h",

--- a/resources/osx-au/Info.plist
+++ b/resources/osx-au/Info.plist
@@ -32,7 +32,7 @@
 	<key>CFBundleIconFile</key>
 	<string>surgeicon</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.vemberaudio.audiounit.surge</string>
+	<string>com.vemberaudio.plugins.surge</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/resources/osx-vst2/Info.plist
+++ b/resources/osx-vst2/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string>surgeicon.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.vemberaudio.vst.surge</string>
+	<string>com.vemberaudio.plugins.surge</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/src/au/aulayer_cocoaui.h
+++ b/src/au/aulayer_cocoaui.h
@@ -1,0 +1,13 @@
+//
+//  aulayer_cocoaui.h
+//  surge-au
+//
+//  Created by Paul Walker on 12/10/18.
+//
+
+#ifndef aulayer_cocoaui_h
+#define aulayer_cocoaui_h
+
+#import <AudioToolbox/AudioUnit.h>
+
+#endif /* aulayer_cocoaui_h */

--- a/src/au/aulayer_cocoaui.mm
+++ b/src/au/aulayer_cocoaui.mm
@@ -1,0 +1,242 @@
+//
+//  aulayer_cocoaui.mm
+//  surge-au
+//
+//  Created by Paul Walker on 12/10/18.
+//
+/*
+    OK so how do cocoa uis work in AU2? There's two things
+ 
+ 1: You return a valid AudioUnitViewInfo which contains basically a bundle URL and class name. You implement this in GetProperty in
+ response to kAudioUnitPropert_CocoaUI
+ 
+ 2: You make that class that you return match the AUCococUIBase protocol which requires it to be able to create a frame
+ 
+ Now the question is how does that frame get a reference to your audio unit? Well there's trick three, which is the uiForAudioUnit has to
+ use the property mechanism to get a reference to an editor. In this case I do that by sending the kVmBAudioUnitPropert_GetEditPointer
+ which I basically just made up. That returns (in this case) a pointer to a SurgeGUIEditor which uses a subset of the VST api
+ (only the public API) to give you a drawable element.
+ 
+ The other trick to make this all work is that Surge itself works by having parameter changes which imapct other parameter changes
+ (like when you change patch number it changes patch name) just update parameters and not redraw. This makes sense for all
+ the obvious reasons (thread locality; bunched drawing; etc...). You can see the refresh_param_quuee and refresh_control_queue
+ implementation which just keep getting stacked up. But to unstack them you need to call a redraw, basically, and that's what the
+ editor ::idle method does. So the final thing to make it all work is to spin up a CFRunLoopTimer (not an NSTImer, note; I tried and
+ that's not the way to go) to call ::idle every 50ms.
+ 
+ And that's what this code does.
+ 
+ */
+
+#include <objc/runtime.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <AudioUnit/AUCocoaUIView.h>
+#include "aulayer.h"
+#include "aulayer_cocoaui.h"
+#include <gui/SurgeGUIEditor.h>
+
+
+
+@interface SurgeNSView : NSView
+{
+    SurgeGUIEditor *editController;
+    CFRunLoopTimerRef idleTimer;
+}
+
+- (id) initWithSurge: (SurgeGUIEditor *) cont preferredSize: (NSSize) size;
+- (void) doIdle;
+- (void) dealloc;
+
+@end
+
+@interface SurgeCocoaUI : NSObject<AUCocoaUIBase>
+{
+}
+
+- (NSString *) description;
+@end
+
+@implementation SurgeCocoaUI
+- (NSView *) uiViewForAudioUnit: (AudioUnit) inAudioUnit
+                       withSize: (NSSize) inPreferredSize
+{
+    // Remember we end up being called here because that's what AUCocoaUIView does in the initiation collaboration with hosts
+    AULOG::log( "uiViewForAudioUnit %s on %s\n", __TIME__, __DATE__ );
+   
+    SurgeGUIEditor* editController = 0;
+    UInt32 size = sizeof (SurgeGUIEditor *);
+    if (AudioUnitGetProperty (inAudioUnit, kVmbAAudioUnitProperty_GetEditPointer, kAudioUnitScope_Global, 0, &editController, &size) != noErr)
+        return nil;
+    
+    return [[[SurgeNSView alloc] initWithSurge:editController preferredSize:inPreferredSize] autorelease];
+    // return nil;
+}
+
+- (unsigned int)interfaceVersion {
+    return 0;
+}
+
+- (NSString *) description {
+    return [NSString stringWithUTF8String: "Surge View"];
+}
+
+@end
+
+void timerCallback( CFRunLoopTimerRef timer, void *info )
+{
+    SurgeNSView *view = (SurgeNSView *)info;
+    [view doIdle];
+}
+
+@implementation SurgeNSView
+- (id) initWithSurge: (SurgeGUIEditor *) cont preferredSize: (NSSize) size
+{
+    self = [super initWithFrame: NSMakeRect (0, 0, size.width / 2, size.height / 2)];
+    idleTimer = nil;
+    editController = cont;
+    if (self)
+    {
+        AULOG::log( "Opening new editor view\n" );
+        cont->open( self );
+        
+        ERect *vr;
+        if (cont->getRect(&vr))
+        {
+            NSRect newSize = NSMakeRect (0, 0, vr->right - vr->left, vr->bottom - vr->top);
+            [self setFrame:newSize];
+        }
+        
+        CFTimeInterval      TIMER_INTERVAL = .05; // In SurgeGUISynthesizer.h it uses 50 ms
+        CFRunLoopTimerContext TimerContext = {0, self, NULL, NULL, NULL};
+        CFAbsoluteTime             FireTime = CFAbsoluteTimeGetCurrent() + TIMER_INTERVAL;
+        idleTimer = CFRunLoopTimerCreate(kCFAllocatorDefault,
+                                              FireTime,
+                                              TIMER_INTERVAL,
+                                              0, 0,
+                                              timerCallback,
+                                              &TimerContext);
+        if (idleTimer)
+            CFRunLoopAddTimer (CFRunLoopGetMain (), idleTimer, kCFRunLoopCommonModes);
+    }
+    
+    return self;
+}
+
+- (void) doIdle
+{
+    editController->idle();
+}
+
+- (void) dealloc
+{
+    editController->close();
+    if( idleTimer )
+    {
+        CFRunLoopTimerInvalidate( idleTimer );
+    }
+
+    [super dealloc];
+}
+
+@end
+
+
+static CFBundleRef GetBundleFromExecutable (const char* filepath)
+{
+    @autoreleasepool {
+        NSString* execStr = [NSString stringWithCString:filepath encoding:NSUTF8StringEncoding];
+        NSString* macOSStr = [execStr stringByDeletingLastPathComponent];
+        NSString* contentsStr = [macOSStr stringByDeletingLastPathComponent];
+        NSString* bundleStr = [contentsStr stringByDeletingLastPathComponent];
+        return CFBundleCreate (0, (CFURLRef)[NSURL fileURLWithPath:bundleStr isDirectory:YES]);
+    }
+    
+}
+
+//----------------------------------------------------------------------------------------------------
+
+const char* getclamptxt(int id)
+{
+    switch(id)
+    {
+        case 1: return "Macro Parameters";
+        case 2: return "Global / FX";
+        case 3: return "Scene A Common";
+        case 4: return "Scene A Osc";
+        case 5: return "Scene A Osc Mixer";
+        case 6: return "Scene A Filters";
+        case 7: return "Scene A Envelopes";
+        case 8: return "Scene A LFOs";
+        case 9: return "Scene B Common";
+        case 10: return "Scene B Osc";
+        case 11: return "Scene B Osc Mixer";
+        case 12: return "Scene B Filters";
+        case 13: return "Scene B Envelopes";
+        case 14: return "Scene B LFOs";
+    }
+    return "";
+}
+
+ComponentResult aulayer::GetProperty(AudioUnitPropertyID iID, AudioUnitScope iScope, AudioUnitElement iElem, void* outData)
+{
+    if( iScope == kAudioUnitScope_Global )
+    {
+        switch( iID )
+        {
+            case kAudioUnitProperty_CocoaUI:
+                {
+                    auto surgeclass = objc_getClass( "SurgeCocoaUI" );
+                    const char* image = class_getImageName ( surgeclass );
+                    CFBundleRef bundle = GetBundleFromExecutable (image);
+                    CFURLRef url = CFBundleCopyBundleURL (bundle);
+                    CFRetain( url );
+                    CFRelease (bundle);
+
+                    
+                    AudioUnitCocoaViewInfo* info = static_cast<AudioUnitCocoaViewInfo*> (outData);
+                    info->mCocoaAUViewClass[0] = CFStringCreateWithCString(kCFAllocatorDefault, class_getName(surgeclass), kCFStringEncodingUTF8);
+                    info->mCocoaAUViewBundleLocation = url;
+
+                    return noErr;
+                }
+            case kVmbAAudioUnitProperty_GetEditPointer:
+            {
+                if( editor_instance == NULL )
+                {
+                    editor_instance = new SurgeGUIEditor( this, plugin_instance );
+                }
+                void** pThis = (void**)(outData);
+                *pThis = (void*)editor_instance;
+
+                return noErr;
+            }
+            case kAudioUnitProperty_ParameterValueName:
+            {
+                if(!IsInitialized()) return kAudioUnitErr_Uninitialized;
+                AudioUnitParameterValueName *aup = (AudioUnitParameterValueName*)outData;
+                char tmptxt[64];
+                float f;
+                if(aup->inValue) f = *(aup->inValue);
+                else f = plugin_instance->getParameter01(plugin_instance->remapExternalApiToInternalId(aup->inParamID));
+                plugin_instance->getParameterDisplay(plugin_instance->remapExternalApiToInternalId(aup->inParamID),tmptxt,f);
+                aup->outName = CFStringCreateWithCString(NULL,tmptxt,kCFStringEncodingUTF8);
+                return noErr;
+            }
+            case kAudioUnitProperty_ParameterClumpName:
+            {
+                AudioUnitParameterNameInfo *aupn = (AudioUnitParameterNameInfo*)outData;
+                aupn->outName = CFStringCreateWithCString(NULL,getclamptxt(aupn->inID),kCFStringEncodingUTF8);
+                return noErr;
+            }
+            case kVmbAAudioUnitProperty_GetPluginCPPInstance:
+            {
+                void** pThis = (void**)(outData);
+                *pThis = (void*)plugin_instance;
+                return noErr;
+            }
+        }
+    }
+
+    return AUInstrumentBase::GetProperty(iID, iScope, iElem, outData);
+}
+

--- a/src/common/CpuArchitecture.cpp
+++ b/src/common/CpuArchitecture.cpp
@@ -23,6 +23,10 @@ void initCpuArchitecture()
       CpuArchitecture |= CaCMOV;
    if ((1 << 26) & CPUInfo[3])
       CpuArchitecture |= CaSSE2;
+#elif MAC
+    // intel macs always support
+    CpuArchitecture |= CaCMOV;
+    CpuArchitecture |= CaSSE2;
 #else
    __builtin_cpu_init();
    if (__builtin_cpu_supports("sse2"))

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -28,6 +28,29 @@ float samplerate, samplerate_inv;
 double dsamplerate, dsamplerate_inv;
 double dsamplerate_os, dsamplerate_os_inv;
 
+#if MAC
+#include <CoreFoundation/CoreFoundation.h>
+
+string getSelfLocation() {
+    char path[PATH_MAX];
+
+    CFStringRef selfName = CFSTR("com.vemberaudio.plugins.surge");
+    CFBundleRef mainBundle = CFBundleGetBundleWithIdentifier(selfName);
+    CFURLRef resourcesURL = CFBundleCopyBundleURL(mainBundle);
+    CFStringRef str = CFURLCopyFileSystemPath( resourcesURL, kCFURLPOSIXPathStyle );
+    CFRelease(resourcesURL);
+    
+    CFStringGetCString( str, path, FILENAME_MAX, kCFStringEncodingASCII );
+    CFRelease(str);
+    
+    string out(path);
+    fprintf(stderr, path);
+    
+//    fileLocation = CFBundleCopyResourceURL(gameBundle, filename, fileExtension, subdirectory);
+    return out;
+}
+#endif
+
 SurgeStorage::SurgeStorage()
 {
    _patch.reset(new SurgePatch(this));
@@ -152,8 +175,11 @@ SurgeStorage::SurgeStorage()
    }
 
 #endif
+#if MAC
+    string snapshotmenupath = getSelfLocation() + "/Contents/Resources/configuration.xml";
+#else
    string snapshotmenupath = datapath + "configuration.xml";
-
+#endif
    if (!snapshotloader.LoadFile(snapshotmenupath.c_str())) // load snapshots (& config-stuff)
    {
 #if !MAC && !__linux__

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -49,6 +49,15 @@ string getSelfLocation() {
 
 SurgeStorage::SurgeStorage()
 {
+#if MAC
+    // Quick hack to install all the bundled surge data to user's local ~/Library/...
+    fs::path userSurgeDir(string(getenv("HOME")) + "/Library/Application Support/Surge");
+    if (!fs::is_directory(userSurgeDir)) {
+        fs::create_directories(userSurgeDir);
+        fs::copy_recursive(fs::path(getSelfLocation() + "/Contents/Data"), userSurgeDir);
+    }
+#endif
+
    _patch.reset(new SurgePatch(this));
 
    float cutoff = 0.455f;
@@ -175,15 +184,6 @@ SurgeStorage::SurgeStorage()
 
    if (!snapshotloader.LoadFile(snapshotmenupath.c_str())) // load snapshots (& config-stuff)
    {
-#if MAC
-       fs::path userSurgeDir(string(getenv("HOME")) + "/Library/Application Support/Surge");
-       // Quick hack to install all the bundled surge data to user's local ~/Library/...
-       fs::create_directories(userSurgeDir); // Okay if this already exists
-       
-       fs::copy_recursive(fs::path(getSelfLocation() + "/Contents/Data"), userSurgeDir);
-       
-       snapshotloader.LoadFile(snapshotmenupath.c_str());
-#endif
 #if !MAC && !__linux__
       MessageBox(::GetActiveWindow(), "Surge is not properly installed. Please reinstall.",
                  "Configuration not found", MB_OK | MB_ICONERROR);

--- a/src/common/gui/COscillatorDisplay.cpp
+++ b/src/common/gui/COscillatorDisplay.cpp
@@ -101,8 +101,8 @@ void COscillatorDisplay::draw(CDrawContext* dc)
                else if (dimax < last_imin)
                   dimax = last_imin;
             }
-            dimin = limit_range(dimin, 0, h);
-            dimax = limit_range(dimax, 0, h);
+            dimin = limit_range(dimin, 0, h-1);
+            dimax = limit_range(dimax, 0, h-1);
 
             // int yp = (int)((float)(size.height() * (-osc->output[block_pos]*0.5+0.5)));
             // yp = limit_range(yp,0,h-1);

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1160,6 +1160,10 @@ bool PLUGIN_API SurgeGUIEditor::open(void* parent, const PlatformType& platformT
 
 void SurgeGUIEditor::close()
 {
+#ifndef TARGET_VST3
+  super::close();
+#endif
+  
 #ifdef TARGET_VST3
    _idleTimer->stop();
 #endif

--- a/src/common/vt_dsp/basic_dsp.cpp
+++ b/src/common/vt_dsp/basic_dsp.cpp
@@ -81,7 +81,7 @@ unsigned int Max(unsigned int a, unsigned int b)
 
 int limit_range(int x, int l, int h)
 {
-#if _M_X64 || PPC || __linux__
+#if _M_X64 || PPC || __linux__ || MAC
    return max(min(x, h), l);
 #else
    __asm


### PR DESCRIPTION
Some drop-downs didn't work because they were expecting a file in `/Library/Application Support/Surge/configuration.xml`, which I assume was put there from an installer. This just moves it into the bundle and loads it from there. Also builds off of #69 