### PR TITLE
Minor change to build-osx.sh

### DIFF
--- a/build-osx.sh
+++ b/build-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 premake5 xcode4
-if [ -n "$VST2SDK_DIR"]; then
+if [ -n "$VST2SDK_DIR" ]; then
 	xcodebuild clean -project surge-vst2.xcodeproj
 	xcodebuild build -configuration Release -project surge-vst2.xcodeproj
 fi

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 premake5 xcode4
-xcodebuild build -configuration Release -project surge-vst2.xcodeproj
+if [ -n "$VST2SDK_DIR"]; then
+	xcodebuild clean -project surge-vst2.xcodeproj
+	xcodebuild build -configuration Release -project surge-vst2.xcodeproj
+fi
+xcodebuild clean -project surge-vst3.xcodeproj
 xcodebuild build -configuration Release -project surge-vst3.xcodeproj
+xcodebuild clean -project surge-au.xcodeproj
 xcodebuild build -configuration Release -project surge-au.xcodeproj


### PR DESCRIPTION
I made a couple of small changes to the macOS build script
 - only build the VST2 if the environment variable is set (could have also done this by checking for the existence of the project).
 - `clean` the projects before building, perhaps this wasn't necessary, feel free to remove those.