### PR TITLE
Project target/template for a standalone app

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -494,3 +494,39 @@ if (os.istarget("macosx")) then
 	postbuildcommands { "./package-au.sh" }
 	
 end
+
+if (os.istarget("linux")) then
+    project "surge-app"
+    kind "WindowedApp"
+
+    defines
+    {
+        "TARGET_APP=1"
+    }
+
+    plugincommon()
+
+    files {
+        "src/app/main.cpp",
+        "src/app/PluginLayer.cpp",
+        VSTGUI .. "plugin-bindings/plugguieditor.cpp",
+    }
+
+    includedirs {
+        "src/app"
+    }
+
+    links {
+        "dl",
+        "freetype",
+        "fontconfig",
+        "X11",
+    }
+
+    configuration { "Debug" }
+    targetdir "target/app/Debug"
+    targetsuffix "-Debug"
+
+    configuration { "Release" }
+    targetdir "target/app/Release"
+end

--- a/src/app/PluginLayer.cpp
+++ b/src/app/PluginLayer.cpp
@@ -1,0 +1,11 @@
+#include "PluginLayer.h"
+#include "globals.h"
+#include "SurgeSynthesizer.h"
+
+void PluginLayer::updateDisplay()
+{
+}
+
+void PluginLayer::sendParameterAutomation(long index, float value)
+{
+}

--- a/src/app/PluginLayer.h
+++ b/src/app/PluginLayer.h
@@ -1,0 +1,8 @@
+#include "SurgeSynthesizer.h"
+
+class PluginLayer
+{
+public:
+   void updateDisplay();
+   void sendParameterAutomation(long index, float value);
+};

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,0 +1,11 @@
+#include "globals.h"
+#include "CpuArchitecture.h"
+#include "SurgeSynthesizer.h"
+#include <float.h>
+
+namespace VSTGUI { void* soHandle = nullptr; }
+
+int main(int argc, char **argv)
+{
+   return 0;
+}

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -16,6 +16,9 @@
 #elif TARGET_VST3
 #include "SurgeVst3Processor.h"
 #include "vstgui/plugin-bindings/plugguieditor.h"
+#elif TARGET_APP
+#include "PluginLayer.h"
+#include "vstgui/plugin-bindings/plugguieditor.h"
 #else
 #include "Vst2PluginInstance.h"
 #include "vstgui/plugin-bindings/aeffguieditor.h"
@@ -676,6 +679,8 @@ void SurgeSynthesizer::sendParameterAutomation(long index, float value)
       // getParent()->ParameterUpdate(externalparam);
 #elif TARGET_VST3
       getParent()->setParameterAutomated(externalparam, value);
+#elif TARGET_APP
+      getParent()->sendParameterAutomation(externalparam, value);
 #else
       getParent()->setParameterAutomated(externalparam, value);
 #endif

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -21,9 +21,11 @@ typedef aulayer PluginLayer;
 #elif TARGET_VST3
 class SurgeVst3Processor;
 typedef SurgeVst3Processor PluginLayer;
-#else
+#elif TARGET_VST2
 class Vst2PluginInstance;
 using PluginLayer = Vst2PluginInstance;
+#else
+class PluginLayer;
 #endif
 
 class SurgeSynthesizer : public AbstractSynthesizer

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -12,9 +12,12 @@ typedef PluginGUIEditor EditorType;
 #elif TARGET_VST3
 #include "public.sdk/source/vst/vstguieditor.h"
 typedef Steinberg::Vst::VSTGUIEditor EditorType;
-#else
+#elif TARGET_VST2
 #include <vstgui/plugin-bindings/aeffguieditor.h>
 typedef AEffGUIEditor EditorType;
+#else
+#include <vstgui/plugin-bindings/plugguieditor.h>
+typedef PluginGUIEditor EditorType;
 #endif
 
 #include "SurgeStorage.h"


### PR DESCRIPTION
Add a new target to premake5.lua called app that builds a standalone
application. Surge (and VSTGUI) files  are linked to the final
executable but it does not do anything useful yet. This just the initial
plumbing needed.

In addition, the target is only available on Linux. This is done
purpose. It is better to make it first work on one platform, and after
it is fully working, scale it to the other platforms. They are easy to
add once app itself is not a moving platform.

Linux is the most reasonable choice for this because on that platform
the standalone app is most desperately needed for development as plugin
targets do not work properly yet. Then, at least one target will support
Linux and probably the plugin issues get more easily fixed.

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>
