### PR TITLE
Pass AU Validation (move Surge.component to /Library and not ~/Library )

### DIFF
--- a/installer-local-au.sh
+++ b/installer-local-au.sh
@@ -3,8 +3,8 @@
 #touch src/au/aulayer.cpp
 xcodebuild build -configuration Release -project surge-au.xcodeproj || exit 1
 ./package-au.sh
-rm -rf ~/Library/Audio/Plug-Ins/Components/Surge.component
-mv products/Surge.component ~/Library/Audio/Plug-Ins/Components
+rm -rf /Library/Audio/Plug-Ins/Components/Surge.component
+mv products/Surge.component /Library/Audio/Plug-Ins/Components
 
 mkdir -p ~/Library/Application\ Support/Surge
 


### PR DESCRIPTION
@baconpaul @kzantow @asimilon you guys might find this of interest.

Problem: If running `installer-local-au.sh`, the AU Validation fails. Time to lit hair on fire and run around in a state of absolute panic. Something's wrong. Well, what could it be?

Upon closer inspection, the AU Validation is done based on components available in /Library/Audio/Plug-Ins/Component - if the file is in ~/Library/Audio/Plug-Ins/Component - it'll time out and you'll feel like something is wrong.

Simple fix: remove two `~`'s from the scrip.  Result: script now deletes the Surge.component in /Library - and moves the Surge.component to /Library. This means that the AU Validation will succeed instead of failing.

Pros: most apps will read /Library (global plugin folder) and might not even offer the possibility of having a secondary plugin folder (set to ~/Library )

Cons: here's yet another PR..
