### PR TITLE
check for submodules, prompt to get them.

### DIFF
--- a/build-osx.sh
+++ b/build-osx.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
-if [[ ! -f vst3sdk/LICENSE.txt ]]; then
-  Echo You have not gotten the submodules required to build Surge. Run the following command to get them.
-  Echo git submodule update --init --recursive
+
+if [ ! -f vst3sdk/LICENSE.txt ]; then
+  echo You have not gotten the submodules required to build Surge. Run the following command to get them.
+  echo git submodule update --init --recursive
   exit
 fi
 

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+if [[ ! -f vst3sdk/LICENSE.txt ]]; then
+  Echo You have not gotten the submodules required to build Surge. Run the following command to get them.
+  Echo git submodule update --init --recursive
+  exit
+fi
+
 premake5 xcode4
 if [ -n "$VST2SDK_DIR" ]; then
 	xcodebuild clean -project surge-vst2.xcodeproj


### PR DESCRIPTION
check for submodules, if `vst3sdk/LICENSE.txt` not found, tell the user to get the submodules.
if the user has the submodules, start building as usual.
discussion from #73 
@baconpaul thanks for the suggestions 