### PR TITLE
Users can save patches on MacOS now

### DIFF
--- a/libs/filesystem/filesystem.cpp
+++ b/libs/filesystem/filesystem.cpp
@@ -10,8 +10,6 @@
 #ifdef TARGET_OS_MAC
 
 #include "filesystem.h"
-#include <cstring>
-#include <cstdio>
 
 namespace std::experimental::filesystem {
     // path class:

--- a/libs/filesystem/filesystem.cpp
+++ b/libs/filesystem/filesystem.cpp
@@ -10,6 +10,8 @@
 #ifdef TARGET_OS_MAC
 
 #include "filesystem.h"
+#include <cstring>
+#include <cstdio>
 
 namespace std::experimental::filesystem {
     // path class:
@@ -85,12 +87,27 @@ namespace std::experimental::filesystem {
     }
     
     void create_directories(path p) {
-        mode_t nMode = 0733; // UNIX style permissions
+        mode_t nMode = 0755; // UNIX style permissions
         int nError = 0;
 #if defined(_WIN32)
         nError = _mkdir(p.c_str()); // can be used on Windows
 #else
-        nError = mkdir(p.c_str(), nMode); // can be used on non-Windows
+        // create_directories is recursive so this solution
+        // nError = mkdir(p.c_str(), nMode); // can be used on non-Windows
+        // doesn't work if you are creating two or 3 layers.
+        // From: https://stackoverflow.com/questions/2336242/recursive-mkdir-system-call-on-unix
+        char* pos;
+        char file_path[PATH_MAX];
+        sprintf( file_path, "%s", p.c_str() ); // I need a non-const char* so have to copy
+        for (pos=strchr(file_path+1, '/'); pos; pos=strchr(pos+1, '/')) {
+            *pos='\0';
+            if (mkdir(file_path, nMode)==-1) {
+                if (errno!=EEXIST) { *pos='/'; return; }
+            }
+            *pos='/';
+        }
+        // and clean up the end
+        nError = mkdir(file_path, nMode );
 #endif
         if (nError != 0) {
             // handle your error here

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -166,8 +166,10 @@ SurgeStorage::SurgeStorage()
       datapath += "/Surge/";
    }
 
-   userDataPath = "~/Documents/Surge";
-
+   // ~/Documents/Surge in full name
+   sprintf( path, "%s/Documents/Surge", getenv( "HOME" ) );
+   userDataPath = path;
+   
 #elif __linux__
 
    /*


### PR DESCRIPTION
As mentioned in #127 user patches weren't saving. Now they are.

The first thing - expand ~ with getenv( "HOME" ) was pretty easy

But there's a second thing I'd like someone to peek at. In the stub of experimental::filesystem create_directories (which unlike create_directory is supposed to recurse; it is mkdir -p) was not recursing.

So I made it recurse using a hacked version of a C++ recursive make from stack overflow.

Could someone look at this before I merge it? @kzantow you've been in this code.