### PR TITLE
Mpe with a ROLI Seaboard in Logic and AU

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1453,6 +1453,26 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                contextMenu->addEntry(txt, eid++);
             }
 
+             // Construct submenus for expicit controller mapping
+             COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle);
+             COptionMenu *currentSub;
+             for( int mc = 0; mc < 127; ++mc )
+             {
+                 if( mc % 10 == 0 )
+                 {
+                     currentSub = new COptionMenu( menuRect, 0, 0, 0, 0, kNoDrawStyle );
+                     char name[ 256 ];
+                     sprintf( name, "CC %d -> %d", mc, min( mc+10, 127 ));
+                     midiSub->addEntry( currentSub, name );
+                 }
+                 
+                 char name[ 256 ];
+                 sprintf( name, "CC # %d", mc );
+                 currentSub->addEntry( name, eid++ );
+                 
+             }
+             contextMenu->addEntry( midiSub, "Set Contoller To..." );
+             
             contextMenu->addEntry("-", eid++);
             id_bipolar = eid;
             contextMenu->addEntry("Bipolar", eid++);
@@ -1609,7 +1629,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             if (cancellearn)
                contextMenu->addEntry("Abort learn controller", eid++);
             else
-               contextMenu->addEntry("Learn controller [MIDI]", eid++);
+                contextMenu->addEntry("Learn controller [MIDI]", eid++);
          }
 
          if (p->midictrl >= 0)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1609,7 +1609,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             if (cancellearn)
                contextMenu->addEntry("Abort learn controller", eid++);
             else
-               contextMenu->addEntry("Learn controller [midi]", eid++);
+               contextMenu->addEntry("Learn controller [MIDI]", eid++);
          }
 
          if (p->midictrl >= 0)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1430,6 +1430,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          }
          int ccid = 0;
          int sc = limit_range(synth->storage.getPatch().scene_active.val.i, 0, 1);
+          bool handled = false;
          if (within_range(ms_ctrl1, modsource, ms_ctrl1 + n_customcontrollers - 1))
          {
             ccid = modsource - ms_ctrl1;
@@ -1453,6 +1454,19 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                contextMenu->addEntry(txt, eid++);
             }
 
+         
+            contextMenu->addEntry("-", eid++);
+            id_bipolar = eid;
+            contextMenu->addEntry("Bipolar", eid++);
+            contextMenu->checkEntry(
+                id_bipolar,
+                synth->storage.getPatch().scene[0].modsources[ms_ctrl1 + ccid]->is_bipolar());
+            id_rename = eid;
+            contextMenu->addEntry("Rename", eid++);
+         
+             
+             contextMenu->addEntry("-", eid++);
+             
              // Construct submenus for expicit controller mapping
              COptionMenu *midiSub = new COptionMenu(menuRect, 0, 0, 0, 0, kNoDrawStyle);
              COptionMenu *currentSub;
@@ -1468,19 +1482,17 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                  
                  char name[ 256 ];
                  sprintf( name, "CC # %d", mc );
-                 currentSub->addEntry( name, eid++ );
+                 CCommandMenuItem *cmd = new CCommandMenuItem( name );
+                 cmd->setActions( [this,ccid,mc,&handled](CCommandMenuItem *men) {
+                     handled = true;
+                     synth->storage.controllers[ccid] = mc;
+                     synth->storage.save_midi_controllers();
+                 });
+                 currentSub->addEntry( cmd );
                  
              }
              contextMenu->addEntry( midiSub, "Set Contoller To..." );
              
-            contextMenu->addEntry("-", eid++);
-            id_bipolar = eid;
-            contextMenu->addEntry("Bipolar", eid++);
-            contextMenu->checkEntry(
-                id_bipolar,
-                synth->storage.getPatch().scene[0].modsources[ms_ctrl1 + ccid]->is_bipolar());
-            id_rename = eid;
-            contextMenu->addEntry("Rename", eid++);
          }
 
          int lfo_id = isLFO(modsource) ? modsource - ms_lfo1 : -1;

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1629,11 +1629,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             if (cancellearn)
                contextMenu->addEntry("Abort learn controller", eid++);
             else
-<<<<<<< HEAD
-                contextMenu->addEntry("Learn controller [MIDI]",  eid++);
-=======
                 contextMenu->addEntry("Learn controller [MIDI]", eid++);
->>>>>>> Add the submenus for controller assignment but they don't work yet.
          }
 
          if (p->midictrl >= 0)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1629,7 +1629,11 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             if (cancellearn)
                contextMenu->addEntry("Abort learn controller", eid++);
             else
+<<<<<<< HEAD
                 contextMenu->addEntry("Learn controller [MIDI]",  eid++);
+=======
+                contextMenu->addEntry("Learn controller [MIDI]", eid++);
+>>>>>>> Add the submenus for controller assignment but they don't work yet.
          }
 
          if (p->midictrl >= 0)

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1515,7 +1515,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
          int command = contextMenu->getLastResult();
          frame->removeView(contextMenu, true); // remove from frame and forget
 
-         if (command >= 0)
+         if (command >= 0 && ! handled )
          {
             if (command == id_clearallmr)
             {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1629,7 +1629,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
             if (cancellearn)
                contextMenu->addEntry("Abort learn controller", eid++);
             else
-                contextMenu->addEntry("Learn controller [MIDI]", eid++);
+                contextMenu->addEntry("Learn controller [MIDI]",  eid++);
          }
 
          if (p->midictrl >= 0)


### PR DESCRIPTION
OK so the MPE support in Surge is really quite complete but it wasn't activating properly with the Roli SEABOARD. And this PR has a lot of commits because in all the shuffles of PRs in the last few days I actually screwed up this branch. But @kurasu could I ask you to look at this one? (Look at the diffs not the commits sorry. If the commit splattage really bugs you I can recreate the branch).

I fixed one problem and added one feature

The feature is simple. As well as learning a modulation control you can directly assign it to a CC with a menu. Simple. I thought I would need that. I didn't but lets leave it in here since it is handy with other controllers.

But the real fix is that the ROLI Seabord 49 with firmware 1.1.7 sends an MPE Initialize message which doesn't match the MPE spec. It is close but not quite. So what I did was add a big honking comment and check for the ROLI case also and then turn on MPE.

With this, the unit sounds fantastic. If you are OK with this patch I will also put together a series of MPE patches in the new year (now that I can save patches!) and add those to the Factor folder.

I'm not going to merge this myself without your say-so @kurasu since it is adding a specific device behavior in. But it is a very nice and popular MPE device so I hope you are OK with this solution.