### PR TITLE
VST3: InitDll/ExitDll should already be defined

### DIFF
--- a/src/vst3/surgeentry.cpp
+++ b/src/vst3/surgeentry.cpp
@@ -30,16 +30,6 @@ bool DeinitModule()
    return true;
 }
 
-bool InitDll()
-{
-   return InitModule();
-}
-
-bool ExitDll()
-{
-   return DeinitModule();
-}
-
 //------------------------------------------------------------------------
 //  VST Plug-in Entry
 //------------------------------------------------------------------------


### PR DESCRIPTION
InitDll and ExitDll should only be needed on Windows, and there they
should be defined in dllmain.cpp from the VST SDK.

If someone could test this on Windows, that would be great.
This should work fine, but if there is a problem, I could instead
just wrap the code with #if WINDOWS