### PR TITLE
Integrate spdlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ products/
 installer_osx/installer
 installer_osx/Install_Surge_*.dmg
 build_logs/
+.DS_Store
 
 # IntelliJ IDEA
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ products/
 installer_osx/installer
 installer_osx/Install_Surge_*.dmg
 build_logs/
-.DS_Store
 
 # IntelliJ IDEA
 .idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vst3sdk"]
 	path = vst3sdk
 	url = https://github.com/steinbergmedia/vst3sdk.git
+[submodule "spdlog"]
+	path = spdlog
+	url = https://github.com/gabime/spdlog.git

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -61,7 +61,7 @@ NC=`tput init`
 
 prerequisite_check()
 {
-    if [ ! -f vst3sdk/LICENSE.txt ]; then
+    if [ ! -f vst3sdk/LICENSE.txt ] || [ ! -f spdlog/LICENSE ]; then
         echo
         echo ${RED}ERROR: You have not gotten the submodules required to build Surge. Run the following command to get them.${NC}
         echo
@@ -248,8 +248,11 @@ case $command in
     --uninstall-surge)
         run_uninstall_surge
         ;;
-    *)
+    "")
         default_action
+        ;;
+    *)
+        help_message
         ;;
 esac
 

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -248,11 +248,8 @@ case $command in
     --uninstall-surge)
         run_uninstall_surge
         ;;
-    "")
-        default_action
-        ;;
     *)
-        help_message
+        default_action
         ;;
 esac
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -132,6 +132,7 @@ includedirs {
 	"src/common/thread",
 	"vst3sdk/vstgui4",
 	"vst3sdk",
+	"spdlog/include",
 	"libs/"
 	}
 

--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -1,4 +1,5 @@
 
+#include "SurgeLogger.h"
 #include "aulayer.h"
 #include <gui/SurgeGUIEditor.h>
 #include <AudioToolbox/AudioUnitUtilities.h>
@@ -6,10 +7,6 @@
 #include "aulayer_cocoaui.h"
 
 typedef SurgeSynthesizer sub3_synth;
-
-#ifdef GENERATE_AU_LOG
-FILE* AULOG::lf = NULL;
-#endif
 
 //----------------------------------------------------------------------------------------------------
 
@@ -112,14 +109,11 @@ void aulayer::InitializePlugin()
 {
 	if(!plugin_instance) 
 	{
-          AULOG::log( "SURGE:>> Constructing new plugin\n" );
-          AULOG::log( "     :>> BUILD %s on %s\n", __TIME__, __DATE__ );
-          //sub3_synth* synth = (sub3_synth*)_aligned_malloc(sizeof(sub3_synth),16);
-          //new(synth) sub3_synth(this);
+          spdlog::info( "Constructing new Surge AU Instance" );
+          spdlog::info( "     built {0} on {1}", __TIME__, __DATE__ );
           
           // FIXME: The VST uses a std::unique_ptr<> and we probably should here also
           plugin_instance = new SurgeSynthesizer( this );
-          AULOG::log( "     :>> Plugin Created\n" );
     }
 	assert(plugin_instance);
 }

--- a/src/au/aulayer.h
+++ b/src/au/aulayer.h
@@ -12,38 +12,6 @@ class SurgeGUIEditor;
 class SurgeSynthesizer;
 typedef SurgeSynthesizer plugin;
 
-#define GENERATE_AU_LOG
-struct AULOG
-{
-#ifdef GENERATE_AU_LOG
-    static FILE* lf;
-    
-    static void log( const char* format, ... )
-    {
-        if( lf == NULL )
-        {
-	    char fname[ 1024 ];
-            sprintf( fname, "%s/Library/Logs/Surge.log", getenv( "HOME" ) );
-            lf = fopen( fname, "a" );
-        }
-        va_list args;
-        va_start( args, format );
-        vfprintf( stderr, format, args );
-        va_end( args );
-        if( lf != NULL )
-        {
-            va_start( args, format );
-            vfprintf( lf, format, args );
-            va_end( args );
-            fflush( lf );
-        }
-        
-    }
-#else
-    static void log( const char* format, ... ) { }
-#endif
-};
-
 //-------------------------------------------------------------------------------------------------------
 const CFStringRef rawchunkname = CFSTR("VmbA_chunk");
 

--- a/src/au/aulayer_cocoaui.mm
+++ b/src/au/aulayer_cocoaui.mm
@@ -66,9 +66,6 @@
                        withSize: (NSSize) inPreferredSize
 {
     // Remember we end up being called here because that's what AUCocoaUIView does in the initiation collaboration with hosts
-    AULOG::log( "uiViewForAudioUnit %s on %s\n", __TIME__, __DATE__ );
-    AULOG::log( "prefSize is %f %f\n", inPreferredSize.width, inPreferredSize.height );
-   
     SurgeGUIEditor* editController = 0;
     UInt32 size = sizeof (SurgeGUIEditor *);
     if (AudioUnitGetProperty (inAudioUnit, kVmbAAudioUnitProperty_GetEditPointer, kAudioUnitScope_Global, 0, &editController, &size) != noErr)

--- a/src/common/SurgeLogger.cpp
+++ b/src/common/SurgeLogger.cpp
@@ -1,0 +1,76 @@
+#include "SurgeLogger.h"
+#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/sinks/stdout_sinks.h"
+
+#include "spdlog/logger.h"
+#include "spdlog/async.h"
+#include <memory>
+#include <filesystem.h>
+
+/*
+** This file exists to have a single global static which is initialized at library open time
+** thereby making sure that the log is set up as we want when it runs. 
+**
+** Two parts. The "init" function below sets up the logger in the OS reasonable way.
+** For now it is stderr+~/Library/Logs on macos and stderr only on windows and linux.
+**
+** The second part is the static variable which is initialized with the function call
+*/
+
+namespace SurgeLogInternal
+{
+
+typedef std::shared_ptr< spdlog::logger > log_t;
+namespace fs = std::experimental::filesystem;
+
+log_t internalSurgeLogInit()
+{
+    std::vector<spdlog::sink_ptr> sinks;
+    
+    /*
+    ** Where to put the logfile is actually OS dependent. 
+    ** The approach we take here is to add a pair of sinks
+    ** to the logger, the first to stderr
+    */
+    auto stderrLogger = std::make_shared<spdlog::sinks::stderr_sink_mt>();
+    sinks.push_back( stderrLogger );
+    
+    /*
+    ** And if someone has implemented this for their OS, the second to a standard
+    ** logfile location
+    */
+
+
+#if MAC 
+    char lfb[ PATH_MAX ];
+    sprintf(lfb, "%s/Library/Logs/Surge.log", getenv("HOME"));
+    auto fileSink = make_shared<spdlog::sinks::basic_file_sink_mt> (lfb);
+    sinks.push_back( fileSink );
+#endif
+    
+#if WINDOWS
+    // FIXME: Where's the default log location on windows?
+#endif
+    
+#if __linux__
+    char lfb[ PATH_MAX ];
+    sprintf(lfb, "%s/.cache/Surge", getenv("HOME"));
+    fs::create_directories(fs::path(lfb));
+    
+    sprintf(lfb, "%s/.cache/Surge/Surge.log", getenv("HOME"));
+    auto fileSink = make_shared<spdlog::sinks::basic_file_sink_mt> (lfb);
+    
+    sinks.push_back( fileSink );
+#endif
+    
+    
+    auto logger = std::make_shared<spdlog::logger>("surge", sinks.begin(), sinks.end());
+    spdlog::register_logger(logger);
+    spdlog::set_default_logger(logger);
+    
+    return logger;
+}
+    
+static log_t internal_surge_log_instance = internalSurgeLogInit();
+
+}

--- a/src/common/SurgeLogger.h
+++ b/src/common/SurgeLogger.h
@@ -1,0 +1,10 @@
+/*
+ * SurgeLogger - quick wrapper to hold reference to and bootstrap the spd logger
+ */
+
+#ifndef __SURGELOGGER_INCLUDE__
+#define __SURGELOGGER_INCLUDE__
+
+#include "spdlog/spdlog.h"
+
+#endif // __SURGELOGGER__INCLUDE__


### PR DESCRIPTION
As mentioned in #94 I banged together a small logging class which helped me a lot with getting AU running. After chatting with @jsakkine and @asimilon about how to get a useful logger, we thought about integrating someone else's written fast C++ logger. 

I chose spdlog https://github.com/gabime/spdlog

With this PR, spdlog works and you can use it anywhere if you `#include "SurgeLogger.h"` and then use their native `spdlog::info()` or what not.

And I gotta say, spdlog works great. I accidentally put a log into the render loop on every process block while debugging #146 and while my log file got big, my sound didn't waver.

@jsakkine @asimilon @kzantow and @kurasu interested in review or opinion from any of you. Especially note I added a new git submodule. I hope you like it, because wow, this is super handy for me squashing bugs.