### PR TITLE
Implement miniedit on Cocoa (and thus modulator rename #119)

### DIFF
--- a/src/common/gui/PopupEditorDialog.cpp
+++ b/src/common/gui/PopupEditorDialog.cpp
@@ -92,9 +92,12 @@ void spawn_miniedit_text(char* c, int maxchars)
 }
 #elif MAC_COCOA
 
+#include "cocoa_utils.h"
+
 void spawn_miniedit_text(char* c, int maxchars)
 {
-   // TODO
+  // Bounce this over to objective C by using the CocoaUtils class
+  CocoaUtils::miniedit_text_impl( c, maxchars );
 }
 
 #elif WIN32

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1566,6 +1566,8 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                spawn_miniedit_text(synth->storage.getPatch().CustomControllerLabel[ccid], 16);
                ((CModulationSourceButton*)control)
                    ->setlabel(synth->storage.getPatch().CustomControllerLabel[ccid]);
+                control->setDirty();
+                control->invalid();
                //((gui_slider*)metaparam[ccid])->setLabel(synth->storage.getPatch().CustomControllerLabel[ccid]);
                synth->updateDisplay();
             }

--- a/src/mac/cocoa_utils.h
+++ b/src/mac/cocoa_utils.h
@@ -3,7 +3,9 @@
 
 class CocoaUtils
 {
-   public: static double getDoubleClickInterval();
+public:
+    static double getDoubleClickInterval();
+    static void miniedit_text_impl( char *c, int maxchars );
 };
 
 

--- a/src/mac/cocoa_utils.mm
+++ b/src/mac/cocoa_utils.mm
@@ -5,3 +5,28 @@ double CocoaUtils::getDoubleClickInterval()
 {
    return [NSEvent doubleClickInterval];
 }
+
+void CocoaUtils::miniedit_text_impl( char *c, int maxchars )
+{
+    @autoreleasepool
+    {
+        // Thanks Internet! https://stackoverflow.com/questions/28362472/is-there-a-simple-input-box-in-cocoa
+        NSAlert *msg = [[NSAlert alloc] init];
+        [msg addButtonWithTitle:@"OK"];
+        [msg addButtonWithTitle:@"Cancel"];
+        
+        [msg setMessageText:@"Please Provide the Value"];
+        
+        NSTextField *txt = [[NSTextField alloc] init];
+        [txt setFrame: NSMakeRect(0, 0, 200, 24 )];
+        [txt setStringValue: [NSString stringWithCString:c encoding:NSASCIIStringEncoding] ];
+        
+        [msg setAccessoryView:txt];
+        
+        auto response = [msg runModal];
+        
+        if (response == NSAlertFirstButtonReturn) {
+            strncpy( c, [[txt stringValue] UTF8String], maxchars );
+        }
+    }
+}


### PR DESCRIPTION
A simple NSAlert based implementation of the miniedit; hook into
the PopupDialog for cocoa; and correct invalidation when a change
occurs. Means rename works fixing #119 

I'll merge this tomorrow unless there are comments. Thanks!