### PR TITLE
Remove useless __forceinline and forceinline macros

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -35,7 +35,6 @@ if (os.istarget("macosx")) then
 	defines
 	{
 		"_MM_ALIGN16=__attribute__((aligned(16)))",
-		"__forceinline=inline",
 		"_aligned_malloc(x,a)=malloc(x)",
 		"_aligned_free(x)=free(x)",
 		"stricmp=strcasecmp",
@@ -72,8 +71,6 @@ elseif (os.istarget("linux")) then
 	defines
 	{ 
 		"_MM_ALIGN16=__attribute__((aligned(16)))",
-		"__forceinline=inline",
-		"forceinline=inline",
 		"_aligned_malloc(x,a)=malloc(x)",
 		"_aligned_free(x)=free(x)",
 		"stricmp=strcasecmp",

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -131,7 +131,7 @@ const char window_abberations[9][16] = {"Triangular", "Cosine",       "Blend 1",
                                         "Blend 2",    "Blend 3",      "Ramp",
                                         "Sine Cycle", "Square Cycle", "Rectangular"};
 
-__forceinline bool uses_wavetabledata(int i)
+inline bool uses_wavetabledata(int i)
 {
    switch (i)
    {

--- a/src/common/dsp/BiquadFilter.h
+++ b/src/common/dsp/BiquadFilter.h
@@ -98,7 +98,7 @@ public:
    void process_block(double* data);
    // void process_block_SSE2(double *data);
 
-   __forceinline float process_sample(float input)
+   inline float process_sample(float input)
    {
       a1.process();
       a2.process();
@@ -115,7 +115,7 @@ public:
       return (float)op;
    }
 
-   __forceinline void process_sample_nolag(float& L, float& R)
+   inline void process_sample_nolag(float& L, float& R)
    {
       double op;
 
@@ -130,7 +130,7 @@ public:
       R = (float)op;
    }
 
-   __forceinline void process_sample_nolag(float& L, float& R, float& Lout, float& Rout)
+   inline void process_sample_nolag(float& L, float& R, float& Lout, float& Rout)
    {
       double op;
 
@@ -145,7 +145,7 @@ public:
       Rout = (float)op;
    }
 
-   __forceinline void process_sample_nolag_noinput(float& Lout, float& Rout)
+   inline void process_sample_nolag_noinput(float& Lout, float& Rout)
    {
       double op;
 

--- a/src/common/dsp/DspUtilities.h
+++ b/src/common/dsp/DspUtilities.h
@@ -226,7 +226,7 @@ inline float tanh_fast(float in)
    return ((in > 0.f) ? 1.f : -1.f) * (1.f - denom);
 }
 
-__forceinline double tanh_faster1(double x)
+inline double tanh_faster1(double x)
 {
    const double a = -1 / 3, b = 2 / 15;
    // return tanh(x);
@@ -235,7 +235,7 @@ __forceinline double tanh_faster1(double x)
    return y * x;
 }
 
-__forceinline float clamp01(float in)
+inline float clamp01(float in)
 {
    if (in > 1.0f)
       return 1.0f;
@@ -244,7 +244,7 @@ __forceinline float clamp01(float in)
    return in;
 }
 
-__forceinline float clamp1bp(float in)
+inline float clamp1bp(float in)
 {
    if (in > 1.0f)
       return 1.0f;

--- a/src/common/dsp/HalfrateFilter.h
+++ b/src/common/dsp/HalfrateFilter.h
@@ -35,7 +35,7 @@ public:
    {
       memset(filter_regs, 0, SHR_NSEC * 2 * sizeof(double));
    }
-   __forceinline double process(double x)
+   inline double process(double x)
    {
       double filter_in = x;
       double y;

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -204,7 +204,7 @@ public:
 private:
    void convolute(int voice, bool FM, bool stereo);
    template <bool is_init> void update_lagvals();
-   __forceinline float distort_level(float);
+   inline float distort_level(float);
    bool first_run;
    float oscpitch[max_unison];
    float dc, dc_uni[max_unison], last_level[max_unison];

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -16,17 +16,17 @@ enum lag_entries
    le_pfg,
 };
 
-__forceinline void set1f(__m128& m, int i, float f)
+inline void set1f(__m128& m, int i, float f)
 {
    *((float*)&m + i) = f;
 }
 
-__forceinline void set1i(__m128& m, int e, int i)
+inline void set1i(__m128& m, int e, int i)
 {
    *((int*)&m + e) = i;
 }
 
-__forceinline float get1f(__m128 m, int i)
+inline float get1f(__m128 m, int i)
 {
    return *((float*)&m + i);
 }

--- a/src/common/dsp/VectorizedSvfFilter.h
+++ b/src/common/dsp/VectorizedSvfFilter.h
@@ -13,7 +13,7 @@ public:
 
    void CopyCoeff(const VectorizedSvfFilter& SVF);
 
-   forceinline vFloat CalcBPF(vFloat In)
+   inline vFloat CalcBPF(vFloat In)
    {
       L1 = vMAdd(F1, B1, L1);
       vFloat H1 = vNMSub(Q, B1, vSub(vMul(In, Q), L1));

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -92,7 +92,7 @@ void WindowOscillator::init_default_values()
    oscdata->p[6].val.i = 1;
 }
 
-__forceinline unsigned int BigMULr16(unsigned int a, unsigned int b)
+inline unsigned int BigMULr16(unsigned int a, unsigned int b)
 {
    // 64-bit unsigned multiply with right shift by 16 bits
 #if _M_X64
@@ -119,7 +119,7 @@ __forceinline unsigned int BigMULr16(unsigned int a, unsigned int b)
 }
 
 #if MAC || __linux__
-__forceinline bool _BitScanReverse(unsigned long* result, unsigned long bits)
+inline bool _BitScanReverse(unsigned long* result, unsigned long bits)
 {
    *result = __builtin_ctz(bits);
    return true;

--- a/src/common/precompiled.h
+++ b/src/common/precompiled.h
@@ -4,5 +4,4 @@
 
 #include "globals.h"
 
-#define forceinline __forceinline
 //#include <vt_util/vt_string.h>

--- a/src/common/vt_dsp/basic_dsp.cpp
+++ b/src/common/vt_dsp/basic_dsp.cpp
@@ -598,7 +598,7 @@ void subtract_block(float* __restrict src1,
 
 // Snabba sin(x) substitut
 // work in progress
-__forceinline float sine_float_nowrap(float x)
+inline float sine_float_nowrap(float x)
 {
    // http://www.devmaster.net/forums/showthread.php?t=5784
    const float B = 4.f / M_PI;
@@ -613,7 +613,7 @@ __forceinline float sine_float_nowrap(float x)
    return P * (y * fabs(y) - y) + y; // Q * y + P * y * abs(y)
 }
 
-__forceinline __m128 sine_ps_nowrap(__m128 x)
+inline __m128 sine_ps_nowrap(__m128 x)
 {
    const __m128 B = _mm_set1_ps(4.f / M_PI);
    const __m128 C = _mm_set1_ps(-4.f / (M_PI * M_PI));
@@ -631,7 +631,7 @@ __forceinline __m128 sine_ps_nowrap(__m128 x)
                      y);
 }
 
-__forceinline __m128 sine_xpi_ps_SSE2(__m128 x) // sin(x*pi)
+inline __m128 sine_xpi_ps_SSE2(__m128 x) // sin(x*pi)
 {
    const __m128 B = _mm_set1_ps(4.f);
    const __m128 premul = _mm_set1_ps(16777216.f);

--- a/src/common/vt_dsp/basic_dsp.h
+++ b/src/common/vt_dsp/basic_dsp.h
@@ -43,7 +43,7 @@ void i152float_block(short*, float*, int);
 float sine_ss(unsigned int x);
 int sine(int x);
 
-forceinline float limit_range(float x, float low, float high)
+inline float limit_range(float x, float low, float high)
 {
    float result;
    _mm_store_ss(&result,
@@ -51,7 +51,7 @@ forceinline float limit_range(float x, float low, float high)
    return result;
 }
 
-forceinline __m128 sum_ps_to_ss(__m128 x)
+inline __m128 sum_ps_to_ss(__m128 x)
 {
    /*__m128 a = _mm_add_ss(x,_mm_shuffle_ps(x,x,_MM_SHUFFLE(0,0,0,1)));
    __m128 b =
@@ -61,7 +61,7 @@ forceinline __m128 sum_ps_to_ss(__m128 x)
    return _mm_add_ss(a, _mm_shuffle_ps(a, a, _MM_SHUFFLE(0, 0, 0, 1)));
 }
 
-forceinline __m128 max_ps_to_ss(__m128 x)
+inline __m128 max_ps_to_ss(__m128 x)
 {
    __m128 a = _mm_max_ss(x, _mm_shuffle_ps(x, x, _MM_SHUFFLE(0, 0, 0, 1)));
    __m128 b = _mm_max_ss(_mm_shuffle_ps(x, x, _MM_SHUFFLE(0, 0, 0, 2)),
@@ -76,7 +76,7 @@ inline __m128 hardclip_ss(__m128 x)
    return _mm_max_ss(_mm_min_ss(x, x_max), x_min);
 }
 
-forceinline float rcp(float x)
+inline float rcp(float x)
 {
    _mm_store_ss(&x, _mm_rcp_ss(_mm_load_ss(&x)));
    return x;
@@ -89,14 +89,14 @@ inline __m128d hardclip8_sd(__m128d x)
    return _mm_max_sd(_mm_min_sd(x, x_max), x_min);
 }
 
-forceinline __m128 hardclip_ps(__m128 x)
+inline __m128 hardclip_ps(__m128 x)
 {
    const __m128 x_min = _mm_set1_ps(-1.0f);
    const __m128 x_max = _mm_set1_ps(1.0f);
    return _mm_max_ps(_mm_min_ps(x, x_max), x_min);
 }
 
-forceinline float saturate(float f)
+inline float saturate(float f)
 {
    __m128 x = _mm_load_ss(&f);
    const __m128 x_min = _mm_set_ss(-1.0f);
@@ -106,7 +106,7 @@ forceinline float saturate(float f)
    return f;
 }
 
-forceinline __m128 softclip_ss(__m128 in)
+inline __m128 softclip_ss(__m128 in)
 {
    // y = x - (4/27)*x^3,  x € [-1.5 .. 1.5]
    const __m128 a = _mm_set_ss(-4.f / 27.f);
@@ -123,7 +123,7 @@ forceinline __m128 softclip_ss(__m128 in)
    return t;
 }
 
-forceinline __m128 softclip_ps(__m128 in)
+inline __m128 softclip_ps(__m128 in)
 {
    // y = x - (4/27)*x^3,  x € [-1.5 .. 1.5]
    const __m128 a = _mm_set1_ps(-4.f / 27.f);
@@ -140,7 +140,7 @@ forceinline __m128 softclip_ps(__m128 in)
    return t;
 }
 
-forceinline __m128 tanh7_ps(__m128 x)
+inline __m128 tanh7_ps(__m128 x)
 {
    const __m128 a = _mm_set1_ps(-1.f / 3.f);
    const __m128 b = _mm_set1_ps(2.f / 15.f);
@@ -155,7 +155,7 @@ forceinline __m128 tanh7_ps(__m128 x)
    return _mm_mul_ps(y, x);
 }
 
-forceinline __m128 tanh7_ss(__m128 x)
+inline __m128 tanh7_ss(__m128 x)
 {
    const __m128 a = _mm_set1_ps(-1.f / 3.f);
    const __m128 b = _mm_set1_ps(2.f / 15.f);
@@ -170,12 +170,12 @@ forceinline __m128 tanh7_ss(__m128 x)
    return _mm_mul_ss(y, x);
 }
 
-forceinline __m128 abs_ps(__m128 x)
+inline __m128 abs_ps(__m128 x)
 {
    return _mm_and_ps(x, m128_mask_absval);
 }
 
-forceinline __m128 softclip8_ps(__m128 in)
+inline __m128 softclip8_ps(__m128 in)
 {
    const __m128 a = _mm_set1_ps(-0.00028935185185f);
 
@@ -190,7 +190,7 @@ forceinline __m128 softclip8_ps(__m128 in)
    return t;
 }
 
-forceinline double tanh7_double(double x)
+inline double tanh7_double(double x)
 {
    const double a = -1 / 3, b = 2 / 15, c = -17 / 315;
    // return tanh(x);
@@ -208,7 +208,7 @@ forceinline double tanh7_double(double x)
    return y * x;
 }
 
-forceinline double softclip_double(double in)
+inline double softclip_double(double in)
 {
    const double c0 = (4.0 / 27.0);
    double x = (in > -1.5f) ? in : -1.5;
@@ -218,7 +218,7 @@ forceinline double softclip_double(double in)
    return x - ax * xx;
 }
 
-forceinline double softclip4_double(double in)
+inline double softclip4_double(double in)
 {
    double x = (in > -6.0) ? in : -6.0;
    x = (x < 6.0) ? x : 6.0;
@@ -227,7 +227,7 @@ forceinline double softclip4_double(double in)
    return x - ax * xx;
 }
 
-forceinline double softclip8_double(double in)
+inline double softclip8_double(double in)
 {
    double x = (in > -12.0) ? in : -12.0;
    x = (x < 12.0) ? x : 12.0;
@@ -236,7 +236,7 @@ forceinline double softclip8_double(double in)
    return x - ax * xx;
 }
 
-forceinline double softclip2_double(double in)
+inline double softclip2_double(double in)
 {
    double x = (in > -3.0) ? in : -3.0;
    x = (x < 3.0) ? x : 3.0;
@@ -245,7 +245,7 @@ forceinline double softclip2_double(double in)
    return x - ax * xx;
 }
 
-forceinline float megapanL(float pos) // valid range -2 .. 2 (> +- 1 is inverted phase)
+inline float megapanL(float pos) // valid range -2 .. 2 (> +- 1 is inverted phase)
 {
    if (pos > 2.f)
       pos = 2.f;
@@ -254,7 +254,7 @@ forceinline float megapanL(float pos) // valid range -2 .. 2 (> +- 1 is inverted
    return (1 - 0.75f * pos - 0.25f * pos * pos);
 }
 
-forceinline float megapanR(float pos)
+inline float megapanR(float pos)
 {
    if (pos > 2.f)
       pos = 2.f;

--- a/src/common/vt_dsp/lipol.h
+++ b/src/common/vt_dsp/lipol.h
@@ -12,23 +12,23 @@ public:
 
    lipol_ps();
 
-   forceinline void set_target(float t)
+   inline void set_target(float t)
    {
       currentval = target;
       target = _mm_set_ss(t);
    }
 
-   forceinline void set_target(__m128 t)
+   inline void set_target(__m128 t)
    {
       currentval = target;
       target = t;
    }
-   forceinline void set_target_instantize(float t)
+   inline void set_target_instantize(float t)
    {
       target = _mm_set_ss(t);
       currentval = target;
    }
-   forceinline void set_target_smoothed(float t)
+   inline void set_target_smoothed(float t)
    {
       currentval = target;
       __m128 p1 = _mm_mul_ss(coef, _mm_set_ss(t));
@@ -38,7 +38,7 @@ public:
    void set_blocksize(int bs);
 
    // inline void set_target(__m128 t) { currentval = target; target = t; }
-   forceinline void instantize()
+   inline void instantize()
    {
       currentval = target;
    }

--- a/src/common/vt_dsp/portable_intrinsics.h
+++ b/src/common/vt_dsp/portable_intrinsics.h
@@ -22,17 +22,17 @@
 
 #define vLoad _mm_load_ps
 
-forceinline vFloat vLoad1(float f)
+inline vFloat vLoad1(float f)
 {
    return _mm_load1_ps(&f);
 }
 
-forceinline vFloat vSqrtFast(vFloat v)
+inline vFloat vSqrtFast(vFloat v)
 {
    return _mm_rcp_ps(_mm_rsqrt_ps(v));
 }
 
-forceinline float vSum(vFloat x)
+inline float vSum(vFloat x)
 {
    __m128 a = _mm_add_ps(x, _mm_movehl_ps(x, x));
    a = _mm_add_ss(a, _mm_shuffle_ps(a, a, _MM_SHUFFLE(0, 0, 0, 1)));

--- a/src/common/vt_dsp/vt_dsp_endian.h
+++ b/src/common/vt_dsp/vt_dsp_endian.h
@@ -6,17 +6,17 @@
 #define vt_read_int16BE vt_write_int16BE
 #define vt_read_float32LE vt_write_float32LE
 
-__forceinline int vt_write_int32LE(int t)
+inline int vt_write_int32LE(int t)
 {
    return t;
 }
 
-__forceinline float vt_write_float32LE(float f)
+inline float vt_write_float32LE(float f)
 {
    return f;
 }
 
-__forceinline int vt_write_int32BE(int t)
+inline int vt_write_int32BE(int t)
 {
 #if (__linux__ || MAC || _M_X64)
    return __builtin_bswap32(t);
@@ -25,22 +25,22 @@ __forceinline int vt_write_int32BE(int t)
 #endif
 }
 
-__forceinline short vt_write_int16LE(short t)
+inline short vt_write_int16LE(short t)
 {
    return t;
 }
 
-__forceinline short vt_write_int16BE(short t)
+inline short vt_write_int16BE(short t)
 {
    return ((t << 8) & 0xff00) | ((t >> 8) & 0x00ff);
 }
 
-__forceinline void vt_copyblock_W_LE(short* dst, const short* src, size_t count)
+inline void vt_copyblock_W_LE(short* dst, const short* src, size_t count)
 {
    memcpy(dst, src, count * sizeof(short));
 }
 
-__forceinline void vt_copyblock_DW_LE(int* dst, const int* src, size_t count)
+inline void vt_copyblock_DW_LE(int* dst, const int* src, size_t count)
 {
    memcpy(dst, src, count * sizeof(int));
 }

--- a/src/vst2/vstplugsquartz.h
+++ b/src/vst2/vstplugsquartz.h
@@ -28,7 +28,6 @@
 #include "globals.h"
 
 #define _MM_ALIGN16 __attribute__((aligned(16)))
-#define __forceinline inline
 #define stricmp strcmp
 #define _aligned_malloc(x, y) malloc(x)
 #define _aligned_free(x) free(x)


### PR DESCRIPTION
These macros look fairly useless so just replace the uses with the
"regular" inline.

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>