### PR TITLE
Small fixes for mac build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ products/
 installer_osx/installer
 installer_osx/Install_Surge_*.dmg
 build_logs/
+.DS_Store
 
 # IntelliJ IDEA
 .idea

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -248,8 +248,11 @@ case $command in
     --uninstall-surge)
         run_uninstall_surge
         ;;
-    *)
+    "")
         default_action
+        ;;
+    *)
+        help_message
         ;;
 esac
 


### PR DESCRIPTION
Two small fixes I accidentally swept into the spdlog PR. These
ignore .DS_Store which pops up eventually if you use finder,
and makes sure build-osx gets a valid input or no arg, but
doesn't treat an invalid flag as a no-arg