### PR TITLE
Use alignas() for alignment

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -34,7 +34,6 @@ if (os.istarget("macosx")) then
 	
 	defines
 	{
-		"_MM_ALIGN16=__attribute__((aligned(16)))",
 		"_aligned_malloc(x,a)=malloc(x)",
 		"_aligned_free(x)=free(x)",
 		"stricmp=strcasecmp",
@@ -70,7 +69,6 @@ elseif (os.istarget("linux")) then
 	
 	defines
 	{ 
-		"_MM_ALIGN16=__attribute__((aligned(16)))",
 		"_aligned_malloc(x,a)=malloc(x)",
 		"_aligned_free(x)=free(x)",
 		"stricmp=strcasecmp",

--- a/src/common/AbstractSynthesizer.h
+++ b/src/common/AbstractSynthesizer.h
@@ -66,8 +66,8 @@ public:
    virtual unsigned int saveRaw(void** data) = 0;
 
 public:
-   _MM_ALIGN16 float output[n_outputs][block_size];
-   _MM_ALIGN16 float input[n_inputs][block_size];
+   float output alignas(16)[n_outputs][block_size];
+   float input alignas(16)[n_inputs][block_size];
    timedata time_data;
    bool audio_processing_active;
 };

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -22,7 +22,7 @@
 
 float sinctable alignas(16)[(FIRipol_M + 1) * FIRipol_N * 2];
 float sinctable1X alignas(16)[(FIRipol_M + 1) * FIRipol_N];
-_MM_ALIGN16 short sinctableI16[(FIRipol_M + 1) * FIRipolI16_N];
+short sinctableI16 alignas(16)[(FIRipol_M + 1) * FIRipolI16_N];
 float table_dB alignas(16)[512],
       table_pitch alignas(16)[512],
       table_pitch_inv alignas(16)[512],

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -20,13 +20,16 @@
 #include <Shlobj.h>
 #endif
 
-_MM_ALIGN16 float sinctable[(FIRipol_M + 1) * FIRipol_N * 2];
-_MM_ALIGN16 float sinctable1X[(FIRipol_M + 1) * FIRipol_N];
+float sinctable alignas(16)[(FIRipol_M + 1) * FIRipol_N * 2];
+float sinctable1X alignas(16)[(FIRipol_M + 1) * FIRipol_N];
 _MM_ALIGN16 short sinctableI16[(FIRipol_M + 1) * FIRipolI16_N];
-_MM_ALIGN16 float table_dB[512], table_pitch[512], table_pitch_inv[512], table_envrate_lpf[512],
-    table_envrate_linear[512];
-_MM_ALIGN16 float table_note_omega[2][512];
-_MM_ALIGN16 float waveshapers[8][1024];
+float table_dB alignas(16)[512],
+      table_pitch alignas(16)[512],
+      table_pitch_inv alignas(16)[512],
+      table_envrate_lpf alignas(16)[512],
+      table_envrate_linear alignas(16)[512];
+float table_note_omega alignas(16)[2][512];
+float waveshapers alignas(16)[8][1024];
 float samplerate, samplerate_inv;
 double dsamplerate, dsamplerate_inv;
 double dsamplerate_os, dsamplerate_os_inv;

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -53,7 +53,7 @@ const int FIRoffsetI16 = FIRipolI16_N >> 1;
 
 extern float sinctable alignas(16)[(FIRipol_M + 1) * FIRipol_N * 2];
 extern float sinctable1X alignas(16)[(FIRipol_M + 1) * FIRipol_N];
-extern _MM_ALIGN16 short sinctableI16[(FIRipol_M + 1) * FIRipolI16_N];
+extern short sinctableI16 alignas(16)[(FIRipol_M + 1) * FIRipolI16_N];
 extern float table_dB alignas(16)[512],
              table_pitch alignas(16)[512],
              table_pitch_inv alignas(16)[512],

--- a/src/common/SurgeStorage.h
+++ b/src/common/SurgeStorage.h
@@ -51,13 +51,16 @@ const int FIRoffset = FIRipol_N >> 1;
 const int FIRipolI16_N = 8;
 const int FIRoffsetI16 = FIRipolI16_N >> 1;
 
-extern _MM_ALIGN16 float sinctable[(FIRipol_M + 1) * FIRipol_N * 2];
-extern _MM_ALIGN16 float sinctable1X[(FIRipol_M + 1) * FIRipol_N];
+extern float sinctable alignas(16)[(FIRipol_M + 1) * FIRipol_N * 2];
+extern float sinctable1X alignas(16)[(FIRipol_M + 1) * FIRipol_N];
 extern _MM_ALIGN16 short sinctableI16[(FIRipol_M + 1) * FIRipolI16_N];
-extern _MM_ALIGN16 float table_dB[512], table_pitch[512], table_pitch_inv[512],
-    table_envrate_lpf[512], table_envrate_linear[512];
-extern _MM_ALIGN16 float table_note_omega[2][512];
-extern _MM_ALIGN16 float waveshapers[8][1024];
+extern float table_dB alignas(16)[512],
+             table_pitch alignas(16)[512],
+             table_pitch_inv alignas(16)[512],
+             table_envrate_lpf alignas(16)[512],
+             table_envrate_linear alignas(16)[512];
+extern float table_note_omega alignas(16)[2][512];
+extern float waveshapers alignas(16)[8][1024];
 extern float samplerate, samplerate_inv;
 extern double dsamplerate, dsamplerate_inv;
 extern double dsamplerate_os, dsamplerate_os_inv;
@@ -460,9 +463,9 @@ enum sub3_copysource
 class SurgeStorage
 {
 public:
-   _MM_ALIGN16 float audio_in[2][block_size_os];
-   _MM_ALIGN16 float audio_in_nonOS[2][block_size];
-   //	_MM_ALIGN16 float sincoffset[(FIRipol_M)*FIRipol_N];	// deprecated
+   float audio_in alignas(16)[2][block_size_os];
+   float audio_in_nonOS alignas(16)[2][block_size];
+   //	float sincoffset alignas(16)[(FIRipol_M)*FIRipol_N];	// deprecated
 
    SurgeStorage();
    ~SurgeStorage();

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2235,8 +2235,8 @@ void SurgeSynthesizer::process()
       clear_block_antidenormalnoise(storage.audio_in_nonOS[1], block_size_quad);
    }
 
-   _MM_ALIGN16 float sceneout[2][2][block_size_os];
-   _MM_ALIGN16 float fxsendout[2][2][block_size];
+   float sceneout alignas(16)[2][2][block_size_os];
+   float fxsendout alignas(16)[2][2][block_size];
    bool play_scene[2];
    polydisplay = 0;
 

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -32,8 +32,12 @@ class SurgeSynthesizer : public AbstractSynthesizer
 {
 public:
    // aligned stuff
-   _MM_ALIGN16 SurgeStorage storage;
-   _MM_ALIGN16 lipol_ps FX1, FX2, amp, amp_mute, send[2][2];
+   SurgeStorage storage alignas(16);
+   lipol_ps FX1 alignas(16),
+            FX2 alignas(16),
+            amp alignas(16),
+            amp_mute alignas(16),
+            send alignas(16)[2][2];
 
    // methods
 public:

--- a/src/common/dsp/BiquadFilter.h
+++ b/src/common/dsp/BiquadFilter.h
@@ -20,7 +20,8 @@ union vdouble
 class vlag
 {
 public:
-   _MM_ALIGN16 vdouble v, target_v;
+   vdouble v alignas(16),
+           target_v alignas(16);
    vlag()
    {}
    void init_x87()
@@ -63,10 +64,15 @@ public:
 
 class BiquadFilter
 {
-   //_MM_ALIGN16 lag<double,false> a1,a2,b0,b1,b2;
-   _MM_ALIGN16 vlag a1, a2, b0, b1, b2;
-   _MM_ALIGN16 vdouble reg0, reg1;
-   //_MM_ALIGN16 double reg0R,reg1R;
+   //alignas(16) lag<double,false> a1,a2,b0,b1,b2;
+   vlag a1 alignas(16),
+        a2 alignas(16),
+        b0 alignas(16),
+        b1 alignas(16),
+        b2 alignas(16);
+   vdouble reg0 alignas(16),
+           reg1 alignas(16);
+   //alignas(16) double reg0R,reg1R;
 public:
    BiquadFilter();
    BiquadFilter(SurgeStorage* storage);

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -230,7 +230,7 @@ class WindowOscillator : public Oscillator
 private:
    int IOutputL alignas(16)[block_size_os];
    int IOutputR alignas(16)[block_size_os];
-   _MM_ALIGN16 struct
+   struct
    {
       unsigned int Pos[wt2_suboscs];
       unsigned int SubPos[wt2_suboscs];
@@ -241,7 +241,7 @@ private:
                                                // per-sample scheduling)
       unsigned char Gain[wt2_suboscs][2];
       float DriftLFO[wt2_suboscs][2];
-   } Sub;
+   } Sub alignas(16);
 
 public:
    WindowOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -6,7 +6,8 @@
 class Oscillator
 {
 public:
-   _MM_ALIGN16 float output[block_size_os], outputR[block_size_os];
+   float output alignas(16)[block_size_os],
+         outputR alignas(16)[block_size_os];
    Oscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
    virtual ~Oscillator();
    virtual void init(float pitch, bool is_display = false){};
@@ -105,9 +106,9 @@ public:
    AbstractBlitOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);
 
 protected:
-   _MM_ALIGN16 float oscbuffer[ob_length + FIRipol_N];
-   _MM_ALIGN16 float oscbufferR[ob_length + FIRipol_N];
-   _MM_ALIGN16 float dcbuffer[ob_length + FIRipol_N];
+   float oscbuffer alignas(16)[ob_length + FIRipol_N];
+   float oscbufferR alignas(16)[ob_length + FIRipol_N];
+   float dcbuffer alignas(16)[ob_length + FIRipol_N];
    __m128 osc_out, osc_out2, osc_outR, osc_out2R;
    void prepare_unison(int voices);
    float integrator_hpf;
@@ -125,7 +126,7 @@ class SurgeSuperOscillator : public AbstractBlitOscillator
 {
 private:
    lipol_ps li_hpf, li_DC, li_integratormult;
-   _MM_ALIGN16 float FMphase[block_size_os + 4];
+   float FMphase alignas(16)[block_size_os + 4];
 
 public:
    SurgeSuperOscillator(SurgeStorage* storage, OscillatorStorage* oscdata, pdata* localcopy);

--- a/src/common/dsp/Oscillator.h
+++ b/src/common/dsp/Oscillator.h
@@ -228,8 +228,8 @@ const int wt2_suboscs = 8;
 class WindowOscillator : public Oscillator
 {
 private:
-   _MM_ALIGN16 int IOutputL[block_size_os];
-   _MM_ALIGN16 int IOutputR[block_size_os];
+   int IOutputL alignas(16)[block_size_os];
+   int IOutputR alignas(16)[block_size_os];
    _MM_ALIGN16 struct
    {
       unsigned int Pos[wt2_suboscs];

--- a/src/common/dsp/QuadFilterUnit.cpp
+++ b/src/common/dsp/QuadFilterUnit.cpp
@@ -581,7 +581,8 @@ __m128 COMBquad_SSE2(QuadFilterUnitState* __restrict f, __m128 in)
 
    __m128 a = _mm_mul_ps(f->C[0], m256);
    __m128i e = _mm_cvtps_epi32(a);
-   _MM_ALIGN16 int DTi[4], SEi[4];
+   int DTi alignas(16)[4],
+       SEi alignas(16)[4];
    __m128i DT = _mm_srli_epi32(e, 8);
    _mm_store_si128((__m128i*)DTi, DT);
    __m128i SE = _mm_and_si128(e, m0xff);
@@ -743,14 +744,14 @@ __m128 SINUS_SSE2(__m128 in, __m128 drive)
 #if MAC
    // this should be very fast on C2D/C1D (and there are no macs with K8's)
    // GCC seems to optimize around the XMM -> int transfers so this is needed here
-   _MM_ALIGN16 int e4[4];
+   int e4 alignas(16)[4];
    e4[0] = _mm_cvtsi128_si32(e);
    e4[1] = _mm_cvtsi128_si32(_mm_shufflelo_epi16(e, _MM_SHUFFLE(1, 1, 1, 1)));
    e4[2] = _mm_cvtsi128_si32(_mm_shufflelo_epi16(e, _MM_SHUFFLE(2, 2, 2, 2)));
    e4[3] = _mm_cvtsi128_si32(_mm_shufflelo_epi16(e, _MM_SHUFFLE(3, 3, 3, 3)));
 #else
    // on PC write to memory & back as XMM -> GPR is slow on K8
-   _MM_ALIGN16 short e4[8];
+   short e4 alignas(16)[8];
    _mm_store_si128((__m128i*)&e4, e);
 #endif
 
@@ -830,7 +831,7 @@ __m128 ASYM_SSE2(__m128 in, __m128 drive)
 
 #if MAC
    // this should be very fast on C2D/C1D (and there are no macs with K8's)
-   _MM_ALIGN16 int e4[4];
+   int e4 alignas(16)[4];
    e4[0] = _mm_cvtsi128_si32(e);
    e4[1] = _mm_cvtsi128_si32(_mm_shufflelo_epi16(e, _MM_SHUFFLE(1, 1, 1, 1)));
    e4[2] = _mm_cvtsi128_si32(_mm_shufflelo_epi16(e, _MM_SHUFFLE(2, 2, 2, 2)));
@@ -838,7 +839,7 @@ __m128 ASYM_SSE2(__m128 in, __m128 drive)
 
 #else
    // on PC write to memory & back as XMM -> GPR is slow on K8
-   _MM_ALIGN16 short e4[8];
+   short e4 alignas(16)[8];
    _mm_store_si128((__m128i*)&e4, e);
 #endif
 

--- a/src/common/dsp/SampleAndHoldOscillator.cpp
+++ b/src/common/dsp/SampleAndHoldOscillator.cpp
@@ -329,7 +329,7 @@ void SampleAndHoldOscillator::process_block(
       }
    }
 
-   _MM_ALIGN16 float hpfblock[block_size_os];
+   float hpfblock alignas(16)[block_size_os];
    li_hpf.store_block(hpfblock, block_size_os_quad);
 
    __m128 mdc = _mm_load_ss(&dc);

--- a/src/common/dsp/SurgeSuperOscillator.cpp
+++ b/src/common/dsp/SurgeSuperOscillator.cpp
@@ -458,7 +458,7 @@ void SurgeSuperOscillator::process_block(
       }
    }
 
-   _MM_ALIGN16 float hpfblock[block_size_os];
+   float hpfblock alignas(16)[block_size_os];
    li_hpf.store_block(hpfblock, block_size_os_quad);
 
    __m128 mdc = _mm_load_ss(&dc);

--- a/src/common/dsp/SurgeVoice.cpp
+++ b/src/common/dsp/SurgeVoice.cpp
@@ -484,7 +484,8 @@ bool SurgeVoice::process_block(QuadFilterChainState& Q, int Qe)
    calc_ctrldata<0>(&Q, Qe);
 
    bool is_wide = scene->filterblock_configuration.val.i == fb_wide;
-   _MM_ALIGN16 float tblock[block_size_os], tblock2[block_size_os];
+   float tblock alignas(16)[block_size_os],
+         tblock2 alignas(16)[block_size_os];
    float* tblockR = is_wide ? tblock2 : tblock;
 
    // float ktrkroot = (float)scene->keytrack_root.val.i;

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -17,8 +17,8 @@ class SurgeVoice
 {
 public:
    float output alignas(16)[2][block_size_os];
-   _MM_ALIGN16 lipol_ps osclevels[7];
-   _MM_ALIGN16 pdata localcopy[n_scene_params];
+   lipol_ps osclevels alignas(16)[7];
+   pdata localcopy alignas(16)[n_scene_params];
    float fmbuffer alignas(16)[block_size_os];
    // used for the 2>1<3 FM-mode (Needs the pointer earlier)
 

--- a/src/common/dsp/SurgeVoice.h
+++ b/src/common/dsp/SurgeVoice.h
@@ -16,12 +16,11 @@ struct QuadFilterChainState;
 class SurgeVoice
 {
 public:
-   // 16-byte aligned
-   _MM_ALIGN16 float output[2][block_size_os];
+   float output alignas(16)[2][block_size_os];
    _MM_ALIGN16 lipol_ps osclevels[7];
    _MM_ALIGN16 pdata localcopy[n_scene_params];
-   _MM_ALIGN16 float
-       fmbuffer[block_size_os]; // used for the 2>1<3 FM-mode (Needs the pointer earlier)
+   float fmbuffer alignas(16)[block_size_os];
+   // used for the 2>1<3 FM-mode (Needs the pointer earlier)
 
    SurgeVoice(SurgeStorage* storage,
               SurgeSceneStorage* scene,

--- a/src/common/dsp/VectorizedSvfFilter.cpp
+++ b/src/common/dsp/VectorizedSvfFilter.cpp
@@ -29,9 +29,9 @@ void VectorizedSvfFilter::Reset()
 
 void VectorizedSvfFilter::SetCoeff(float pOmega[4], float QVal, float Spread)
 {
-   vAlign float Freq1[4];
-   vAlign float Freq2[4];
-   vAlign float Quality[4];
+   float Freq1 alignas(16)[4];
+   float Freq2 alignas(16)[4];
+   float Quality alignas(16)[4];
 
    QVal = CalcQ(QVal);
 

--- a/src/common/dsp/WavetableOscillator.cpp
+++ b/src/common/dsp/WavetableOscillator.cpp
@@ -460,7 +460,7 @@ void WavetableOscillator::process_block(
       // li_DC.set_target(dc);
    }
 
-   _MM_ALIGN16 float hpfblock[block_size_os];
+   float hpfblock alignas(16)[block_size_os];
    li_hpf.store_block(hpfblock, block_size_os_quad);
 
    for (k = 0; k < block_size_os; k++)

--- a/src/common/dsp/WindowOscillator.cpp
+++ b/src/common/dsp/WindowOscillator.cpp
@@ -192,7 +192,8 @@ void WindowOscillator::ProcessSubOscs(bool stereo)
                                          _mm_loadu_si128((__m128i*)&WinAdr[WinPos]));
 
             // Sum
-            _MM_ALIGN16 int iWin[4], iWave[4];
+            int iWin alignas(16)[4],
+                iWave alignas(16)[4];
 #if MAC
             // this should be very fast on C2D/C1D (and there are no macs with K8's)
             iWin[0] = _mm_cvtsi128_si32(Win);

--- a/src/common/dsp/effect/ConditionerEffect.cpp
+++ b/src/common/dsp/effect/ConditionerEffect.cpp
@@ -96,7 +96,8 @@ void ConditionerEffect::process(float* dataL, float* dataR)
    width.set_target_smoothed(clamp1bp(*f[2]));
    postamp.set_target_smoothed(db_to_linear(*f[7]));
 
-   _MM_ALIGN16 float M[block_size], S[block_size]; // wb = write-buffer
+   float M alignas(16)[block_size],
+         S alignas(16)[block_size]; // wb = write-buffer
    encodeMS(dataL, dataR, M, S, block_size_quad);
    width.multiply_block(S, block_size_quad);
    decodeMS(M, S, dataL, dataR, block_size_quad);

--- a/src/common/dsp/effect/DistortionEffect.cpp
+++ b/src/common/dsp/effect/DistortionEffect.cpp
@@ -67,8 +67,8 @@ void DistortionEffect::process(float* dataL, float* dataR)
    outgain.set_target_smoothed(db_to_linear(*f[10]));
    float fb = *f[5];
 
-   _MM_ALIGN16 float bL[block_size << dist_OS_bits];
-   _MM_ALIGN16 float bR[block_size << dist_OS_bits];
+   float bL alignas(16)[block_size << dist_OS_bits];
+   float bR alignas(16)[block_size << dist_OS_bits];
    assert(dist_OS_bits == 2);
 
    drive.multiply_2_blocks(dataL, dataR, block_size_quad);

--- a/src/common/dsp/effect/DualDelayEffect.cpp
+++ b/src/common/dsp/effect/DualDelayEffect.cpp
@@ -111,8 +111,10 @@ void DualDelayEffect::process(float* dataL, float* dataR)
 {
    setvars(false);
 
-   _MM_ALIGN16 float tbufferL[block_size], wbL[block_size]; // wb = write-buffer
-   _MM_ALIGN16 float tbufferR[block_size], wbR[block_size];
+   float tbufferL alignas(16)[block_size],
+         wbL alignas(16)[block_size]; // wb = write-buffer
+   float tbufferR alignas(16)[block_size],
+         wbR alignas(16)[block_size];
    int k;
 
    for (k = 0; k < block_size; k++)
@@ -184,7 +186,8 @@ void DualDelayEffect::process(float* dataL, float* dataR)
    }
 
    // scale width
-   _MM_ALIGN16 float M[block_size], S[block_size];
+   float M alignas(16)[block_size],
+         S alignas(16)[block_size];
    encodeMS(tbufferL, tbufferR, M, S, block_size_quad);
    width.multiply_block(S, block_size_quad);
    decodeMS(M, S, tbufferL, tbufferR, block_size_quad);

--- a/src/common/dsp/effect/Effect.cpp
+++ b/src/common/dsp/effect/Effect.cpp
@@ -318,9 +318,9 @@ template <int v> void ChorusEffect<v>::process(float* dataL, float* dataR)
 {
    setvars(false);
 
-   _MM_ALIGN16 float tbufferL[block_size];
-   _MM_ALIGN16 float tbufferR[block_size];
-   _MM_ALIGN16 float fbblock[block_size];
+   float tbufferL alignas(16)[block_size];
+   float tbufferR alignas(16)[block_size];
+   float fbblock alignas(16)[block_size];
    int k;
 
    clear_block(tbufferL, block_size_quad);
@@ -383,7 +383,8 @@ template <int v> void ChorusEffect<v>::process(float* dataL, float* dataR)
          buffer[k + max_delay_length] = buffer[k]; // copy buffer so FIR-core doesn't have to wrap
 
    // scale width
-   _MM_ALIGN16 float M[block_size], S[block_size];
+   float M alignas(16)[block_size],
+         S alignas(16)[block_size];
    encodeMS(tbufferL, tbufferR, M, S, block_size_quad);
    width.multiply_block(S, block_size_quad);
    decodeMS(M, S, tbufferL, tbufferR, block_size_quad);

--- a/src/common/dsp/effect/FreqshiftEffect.cpp
+++ b/src/common/dsp/effect/FreqshiftEffect.cpp
@@ -88,8 +88,12 @@ void FreqshiftEffect::process(float* dataL, float* dataR)
    setvars(false);
 
    int k;
-   _MM_ALIGN16 float L[block_size], R[block_size], Li[block_size], Ri[block_size], Lr[block_size],
-       Rr[block_size];
+   float L alignas(16)[block_size],
+         R alignas(16)[block_size],
+         Li alignas(16)[block_size],
+         Ri alignas(16)[block_size],
+         Lr alignas(16)[block_size],
+         Rr alignas(16)[block_size];
 
    for (k = 0; k < block_size; k++)
    {

--- a/src/common/dsp/effect/Reverb1Effect.cpp
+++ b/src/common/dsp/effect/Reverb1Effect.cpp
@@ -200,7 +200,8 @@ void Reverb1Effect::update_rsize()
 
 void Reverb1Effect::process(float* dataL, float* dataR)
 {
-   _MM_ALIGN16 float wetL[block_size], wetR[block_size];
+   float wetL alignas(16)[block_size],
+         wetR alignas(16)[block_size];
 
    if (fxdata->p[rp_shape].val.i != shape)
       loadpreset(fxdata->p[rp_shape].val.i);
@@ -291,7 +292,8 @@ void Reverb1Effect::process(float* dataL, float* dataR)
    hicut.process_block_slowlag(wetL, wetR);
 
    // scale width
-   _MM_ALIGN16 float M[block_size], S[block_size];
+   float M alignas(16)[block_size],
+         S alignas(16)[block_size];
    encodeMS(wetL, wetR, M, S, block_size_quad);
    width.multiply_block(S, block_size_quad);
    decodeMS(M, S, wetL, wetR, block_size_quad);

--- a/src/common/dsp/effect/Reverb2Effect.cpp
+++ b/src/common/dsp/effect/Reverb2Effect.cpp
@@ -173,7 +173,8 @@ void Reverb2Effect::process(float* dataL, float* dataR)
    float scale = powf(2.f, 1.f * *f[r2p_room_size]);
    calc_size(scale);
 
-   _MM_ALIGN16 float wetL[block_size], wetR[block_size];
+   float wetL alignas(16)[block_size],
+         wetR alignas(16)[block_size];
 
    float loop_time_s = 0.5508 * scale;
    float decay = powf(db60, loop_time_s / (4.f * (powf(2.f, *f[r2p_decay_time]))));
@@ -242,7 +243,8 @@ void Reverb2Effect::process(float* dataL, float* dataR)
    }
 
    // scale width
-   _MM_ALIGN16 float M[block_size], S[block_size];
+   float M alignas(16)[block_size],
+         S alignas(16)[block_size];
    encodeMS(wetL, wetR, M, S, block_size_quad);
    width.multiply_block(S, block_size_quad);
    decodeMS(M, S, wetL, wetR, block_size_quad);

--- a/src/common/dsp/effect/VocoderEffect.cpp
+++ b/src/common/dsp/effect/VocoderEffect.cpp
@@ -95,7 +95,7 @@ void VocoderEffect::process(float* dataL, float* dataR)
       setvars(false);
    }
 
-   _MM_ALIGN16 float modulator_in[block_size];
+   float modulator_in alignas(16)[block_size];
 
    add_block(storage->audio_in_nonOS[0], storage->audio_in_nonOS[1], modulator_in, block_size_quad);
 

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -21,7 +21,12 @@ const int slowrate_m1 = slowrate - 1;
 
 class DualDelayEffect : public Effect
 {
-   _MM_ALIGN16 lipol_ps feedback, crossfeed, pan, mix, width;
+   lipol_ps feedback alignas(16),
+            crossfeed alignas(16),
+            aligpan alignas(16),
+            pan alignas(16),
+            mix alignas(16),
+            width alignas(16);
    float buffer alignas(16)[2][max_delay_length + FIRipol_N];
 
 public:
@@ -57,8 +62,11 @@ private:
 
 template <int v> class ChorusEffect : public Effect
 {
-   _MM_ALIGN16 lipol_ps feedback, mix, width;
-   _MM_ALIGN16 __m128 voicepanL4[v], voicepanR4[v];
+   lipol_ps feedback alignas(16),
+            mix alignas(16),
+            width alignas(16);
+   __m128 voicepanL4 alignas(16)[v],
+          voicepanR4 alignas(16)[v];
    float buffer alignas(16)[max_delay_length + FIRipol_N]; // Includes padding so we can use SSE
                                                            // interpolation without wrapping
 public:
@@ -89,8 +97,9 @@ private:
 class FreqshiftEffect : public Effect
 {
 public:
-   _MM_ALIGN16 halfrate_stereo fr, fi;
-   _MM_ALIGN16 lipol_ps mix;
+   halfrate_stereo fr alignas(16),
+                   fi alignas(16);
+   lipol_ps mix alignas(16);
    FreqshiftEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
    virtual ~FreqshiftEffect();
    virtual const char* get_effectname()
@@ -122,7 +131,7 @@ private:
 
 class Eq3BandEffect : public Effect
 {
-   _MM_ALIGN16 lipol_ps gain;
+   lipol_ps gain alignas(16);
 
 public:
    Eq3BandEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
@@ -151,7 +160,7 @@ private:
 
 class PhaserEffect : public Effect
 {
-   _MM_ALIGN16 lipol_ps mix;
+   lipol_ps mix alignas(16);
    float L alignas(16)[block_size],
          R alignas(16)[block_size];
 
@@ -225,8 +234,10 @@ protected:
 
 class DistortionEffect : public Effect
 {
-   _MM_ALIGN16 halfrate_stereo hr_a, hr_b;
-   _MM_ALIGN16 lipol_ps drive, outgain;
+   halfrate_stereo hr_a alignas(16),
+                   hr_b alignas(16);
+   lipol_ps drive alignas(16),
+            outgain alignas(16);
 
 public:
    DistortionEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
@@ -290,11 +301,11 @@ public:
    virtual int group_label_ypos(int id);
 
 private:
-   _MM_ALIGN16 VectorizedSvfFilter mCarrierL[NVocoderVec];
-   _MM_ALIGN16 VectorizedSvfFilter mCarrierR[NVocoderVec];
-   _MM_ALIGN16 VectorizedSvfFilter mModulator[NVocoderVec];
-   _MM_ALIGN16 vFloat mEnvF[NVocoderVec];
-   _MM_ALIGN16 lipol_ps mGain;
+   VectorizedSvfFilter mCarrierL alignas(16)[NVocoderVec];
+   VectorizedSvfFilter mCarrierR alignas(16)[NVocoderVec];
+   VectorizedSvfFilter mModulator alignas(16)[NVocoderVec];
+   vFloat mEnvF alignas(16)[NVocoderVec];
+   lipol_ps mGain alignas(16);
 
    int mBI; // block increment (to keep track of events not occurring every n blocks)
 
@@ -310,8 +321,10 @@ private:
 
 class emphasize : public Effect
 {
-   _MM_ALIGN16 halfrate_stereo pre, post;
-   _MM_ALIGN16 lipol_ps type, outgain;
+   halfrate_stereo pre alignas(16),
+                   post alignas(16);
+   lipol_ps type alignas(16),
+            outgain alignas(16);
 
 public:
    emphasize(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
@@ -344,7 +357,10 @@ const int lookahead = 1 << 7;
 
 class ConditionerEffect : public Effect
 {
-   _MM_ALIGN16 lipol_ps ampL, ampR, width, postamp;
+   lipol_ps ampL alignas(16),
+            ampR alignas(16),
+            width alignas(16),
+            postamp alignas(16);
 
 public:
    ConditionerEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
@@ -393,7 +409,8 @@ class Reverb1Effect : public Effect
    float out_tap alignas(16)[rev_taps];
    float predelay alignas(16)[max_rev_dly];
    int delay_time alignas(16)[rev_taps];
-   _MM_ALIGN16 lipol_ps mix, width;
+   lipol_ps mix alignas(16),
+            width alignas(16);
 
 public:
    Reverb1Effect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
@@ -484,7 +501,8 @@ class Reverb2Effect : public Effect
       float a0;
    };
 
-   _MM_ALIGN16 lipol_ps mix, width;
+   lipol_ps mix alignas(16),
+            width alignas(16);
 
 public:
    Reverb2Effect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -392,7 +392,7 @@ class Reverb1Effect : public Effect
    float delay alignas(16)[rev_taps * max_rev_dly];
    float out_tap alignas(16)[rev_taps];
    float predelay alignas(16)[max_rev_dly];
-   _MM_ALIGN16 int delay_time[rev_taps];
+   int delay_time alignas(16)[rev_taps];
    _MM_ALIGN16 lipol_ps mix, width;
 
 public:

--- a/src/common/dsp/effect/effect_defs.h
+++ b/src/common/dsp/effect/effect_defs.h
@@ -22,7 +22,7 @@ const int slowrate_m1 = slowrate - 1;
 class DualDelayEffect : public Effect
 {
    _MM_ALIGN16 lipol_ps feedback, crossfeed, pan, mix, width;
-   _MM_ALIGN16 float buffer[2][max_delay_length + FIRipol_N];
+   float buffer alignas(16)[2][max_delay_length + FIRipol_N];
 
 public:
    DualDelayEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
@@ -59,7 +59,7 @@ template <int v> class ChorusEffect : public Effect
 {
    _MM_ALIGN16 lipol_ps feedback, mix, width;
    _MM_ALIGN16 __m128 voicepanL4[v], voicepanR4[v];
-   _MM_ALIGN16 float buffer[max_delay_length + FIRipol_N]; // Includes padding so we can use SSE
+   float buffer alignas(16)[max_delay_length + FIRipol_N]; // Includes padding so we can use SSE
                                                            // interpolation without wrapping
 public:
    ChorusEffect<v>(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
@@ -152,7 +152,8 @@ private:
 class PhaserEffect : public Effect
 {
    _MM_ALIGN16 lipol_ps mix;
-   _MM_ALIGN16 float L[block_size], R[block_size];
+   float L alignas(16)[block_size],
+         R alignas(16)[block_size];
 
 public:
    PhaserEffect(SurgeStorage* storage, FxStorage* fxdata, pdata* pd);
@@ -385,11 +386,12 @@ const int rev_taps = 1 << rev_tap_bits;
 
 class Reverb1Effect : public Effect
 {
-   _MM_ALIGN16 float delay_pan_L[rev_taps], delay_pan_R[rev_taps];
-   _MM_ALIGN16 float delay_fb[rev_taps];
-   _MM_ALIGN16 float delay[rev_taps * max_rev_dly];
-   _MM_ALIGN16 float out_tap[rev_taps];
-   _MM_ALIGN16 float predelay[max_rev_dly];
+   float delay_pan_L alignas(16)[rev_taps],
+         delay_pan_R alignas(16)[rev_taps];
+   float delay_fb alignas(16)[rev_taps];
+   float delay alignas(16)[rev_taps * max_rev_dly];
+   float out_tap alignas(16)[rev_taps];
+   float predelay alignas(16)[max_rev_dly];
    _MM_ALIGN16 int delay_time[rev_taps];
    _MM_ALIGN16 lipol_ps mix, width;
 

--- a/src/common/vt_dsp/portable_intrinsics.h
+++ b/src/common/vt_dsp/portable_intrinsics.h
@@ -41,5 +41,3 @@ inline float vSum(vFloat x)
 
    return f;
 }
-
-#define vAlign _MM_ALIGN16

--- a/src/todo/effect_emphasize.cpp
+++ b/src/todo/effect_emphasize.cpp
@@ -42,8 +42,8 @@ void emphasize::process(float *dataL, float *dataR)
 	bi = (bi+1) & slowrate_m1;	
 	outgain.set_target(storage->db_to_linear(*f[0]));
 
-	_MM_ALIGN16 float bL[block_size << 1];
-	_MM_ALIGN16 float bR[block_size << 1];
+	float bL alignas(16)[block_size << 1];
+	float bR alignas(16)[block_size << 1];
 
 	EQ.process_block_to(dataL,dataR,bL,bR);	
 	

--- a/src/todo/sub3_osc_wavetable2.cpp
+++ b/src/todo/sub3_osc_wavetable2.cpp
@@ -395,7 +395,7 @@ template<bool FM> void osc_wavetable2::process_blockT(float pitch0,float depth,f
 		//li_DC.set_target(dc);	
 	}	
 		
-	_MM_ALIGN16 float hpfblock[block_size_os];			
+	float hpfblock alignas(16)[block_size_os];
 	li_hpf.store_block(hpfblock,block_size_os_quad);		
 
 	for(k=0; k<block_size_os; k++)

--- a/src/vst2/vstplugsquartz.h
+++ b/src/vst2/vstplugsquartz.h
@@ -27,7 +27,6 @@
 #include <vstgui/vstgui.h>
 #include "globals.h"
 
-#define _MM_ALIGN16 __attribute__((aligned(16)))
 #define stricmp strcmp
 #define _aligned_malloc(x, y) malloc(x)
 #define _aligned_free(x) free(x)


### PR DESCRIPTION
Define a generic ALIGN() macro albeit there is only 16-byte aligns. Just
makes the source code more cleaner and obvious. Use _MSC_VER to detect
MSVC vs rest of the world (probably could use that in most of the cases
as the differentiator as 90% of time the same shit works for clang and
GCC). As a side-effect, this will remove some cruft from premake5.lua.

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>