### PR TITLE
Fix Windows installer, add .dll not .vst3

### DIFF
--- a/installer_win/surge.iss
+++ b/installer_win/surge.iss
@@ -38,7 +38,7 @@ Name: VST3; Description: VST3 Plug-in (64 bit); Types: full compact custom; Flag
 
 [Files]
 Source: ..\target\vst2\Release\Surge.dll; DestDir: {app}; Components: VST2; Flags: ignoreversion
-Source: ..\target\vst3\Release\Surge.vst3; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
+Source: ..\target\vst3\Release\Surge.dll; DestDir: {cf}\VST3; Components: VST3; Flags: ignoreversion
 Source: ..\resources\data\*; DestDir: {localappdata}\Surge; Components: Data; Flags: recursesubdirs; Excludes: "*.git";
 
 [Languages]


### PR DESCRIPTION
@baconpaul this is breaking during windows installer creation because it should be a `.dll`