### PR TITLE
Make switches and so on invalidate in GUI

### DIFF
--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -112,6 +112,7 @@ private:
    CControl* polydisp = nullptr;
    CControl* oscdisplay = nullptr;
    CControl* param[1024] = {};
+   CControl* nonmod_param[1024] = {}; 
    CControl* gui_modsrc[n_modsources] = {};
    CControl* metaparam[n_customcontrollers] = {};
    CControl* lfodisplay = nullptr;


### PR DESCRIPTION
When you have external (like DAW) controlled items
which are not continuous sliders they didn't change.
See #160. To fix this we need to keep a reference to
them in the refresh_params update idle look. This
implements that and keeps a reference on a few key controls.

This is a partial fix to the bug. See my request in #160 for help finding the next set of controls which don't work.