### PR TITLE
Save correct creator name

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2037,7 +2037,7 @@ void SurgeGUIEditor::valueChanged(CControl* control)
       frame->setDirty();
 
       synth->storage.getPatch().name = patchName->getText();
-      synth->storage.getPatch().author = patchName->getText();
+      synth->storage.getPatch().author = patchCreator->getText();
       synth->storage.getPatch().category = patchCategory->getText();
       synth->storage.getPatch().comment = patchComment->getText();
       synth->savePatch();


### PR DESCRIPTION
The Author name is not the Patch name; the Author name is the Creator. This fixes the second issue in #186.