### PR TITLE
Macintosh was using SSE1 

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -4,6 +4,7 @@
 #include <AudioToolbox/AudioUnitUtilities.h>
 #include <AudioUnit/AudioUnitCarbonView.h>
 #include "aulayer_cocoaui.h"
+#include "CpuArchitecture.h"
 
 typedef SurgeSynthesizer sub3_synth;
 
@@ -110,6 +111,7 @@ void aulayer::InitializePlugin()
 	{
           //sub3_synth* synth = (sub3_synth*)_aligned_malloc(sizeof(sub3_synth),16);
           //new(synth) sub3_synth(this);
+          initCpuArchitecture();
           
           // FIXME: The VST uses a std::unique_ptr<> and we probably should here also
           plugin_instance = new SurgeSynthesizer( this );


### PR DESCRIPTION
because cpuInitialization was never
occuring. This leads to the ancilliary effect of using the
broken SSE1 implementation of the asym waveshaper.

This fixes it by explicitly calling the cpu initialization.

See Issue #181 for more commentary.