### PR TITLE
Activate CPU Configuration in VST2

### DIFF
--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -24,10 +24,13 @@ using namespace std;
 namespace VSTGUI { void* soHandle = nullptr; }
 #endif
 
+#include "CpuArchitecture.h"
+
 //-------------------------------------------------------------------------------------------------------
 
 AudioEffect* createEffectInstance(audioMasterCallback audioMaster)
 {
+   initCpuArchitecture();
    return new Vst2PluginInstance(audioMaster);
 }
 


### PR DESCRIPTION
As discovered in #181 on VST2 set up CPUInfo properly. This change
fixes that, allowing SSE2 instructions to fire and the associated
audio render bugs to be corrected.