### PR TITLE
One more initialization tweak

### DIFF
--- a/src/au/aulayer.cpp
+++ b/src/au/aulayer.cpp
@@ -4,7 +4,7 @@
 #include <AudioToolbox/AudioUnitUtilities.h>
 #include <AudioUnit/AudioUnitCarbonView.h>
 #include "aulayer_cocoaui.h"
-#include "CpuArchitecture.h"
+#include "AbstractSynthesizer.h"
 
 typedef SurgeSynthesizer sub3_synth;
 
@@ -111,7 +111,7 @@ void aulayer::InitializePlugin()
 	{
           //sub3_synth* synth = (sub3_synth*)_aligned_malloc(sizeof(sub3_synth),16);
           //new(synth) sub3_synth(this);
-          initCpuArchitecture();
+          initDllGlobals(); // this is a slightly misnamed function since only windows has dlls; it does all setup stuff for globals
           
           // FIXME: The VST uses a std::unique_ptr<> and we probably should here also
           plugin_instance = new SurgeSynthesizer( this );

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -24,13 +24,13 @@ using namespace std;
 namespace VSTGUI { void* soHandle = nullptr; }
 #endif
 
-#include "CpuArchitecture.h"
+#include "AbstractSynthesizer.h"
 
 //-------------------------------------------------------------------------------------------------------
 
 AudioEffect* createEffectInstance(audioMasterCallback audioMaster)
 {
-   initCpuArchitecture();
+   initDllGlobals(); // this is a slightly misnamed function since only windows has dlls; it does all setup stuff for globals
    return new Vst2PluginInstance(audioMaster);
 }
 


### PR DESCRIPTION
Rather than call initCpuArchitecture directly, call initDllGlobals
in each startup path, which just calls initCpuArchitecture for now
but guarantees a consistent DLL initialization path.