### PR TITLE
Update Windows compiler requirements and enable over-aligned allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Prerequisites
 
 * [Git](https://git-scm.com/downloads)
 * [Premake 5](https://premake.github.io/download.html#v5) for generating project files
-* [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/)
+* [Visual Studio 15.5 (at least)](https://visualstudio.microsoft.com/downloads/)
 * [Inno Setup](http://jrsoftware.org/isdl.php) for building the installer
 
 To build with Windows, run

--- a/premake5.lua
+++ b/premake5.lua
@@ -103,7 +103,7 @@ elseif (os.istarget("windows")) then
 	nuget { "libpng-msvc-x64:1.6.33.8807" }
 
 	characterset "MBCS"
-	buildoptions { "/MP" }
+	buildoptions { "/MP /Zc:alignedNew" }
 
 	includedirs {
 		"libs/wtl"


### PR DESCRIPTION
Be explicit on minimum version for Visual Studio. 15.5 is a good entry level version for us because it is the first version of Visual Studio that has support for over-aligned allocations. Update premake5.lua to
enable this support. This is needed for SSE2 opcodes that require 16-byte aligned data.

For Linux and macOS we need not to do anything because they align all allocations at least to 16 bytes.

This provides starting point for implementing #188 changes. The use of `_aligned_alloc()` is scattered around the code base. Once the build support over-aligned allocations is landed, the work can be more easily distributed to multiple people.