### PR TITLE
Read version from the file VERSION to the about dialog

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -10,7 +10,8 @@ VSTGUI = "vst3sdk/vstgui4/vstgui/";
 
 defines
 {
-	"VSTGUI_ENABLE_DEPRECATED_METHODS=0"
+    "VSTGUI_ENABLE_DEPRECATED_METHODS=0",
+    "SURGE_VERSION=" .. string.gsub(io.readfile("VERSION"), "\n$", "")
 }
 
 floatingpoint "Fast"

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -31,6 +31,9 @@ static inline int _stricmp(const char *s1, const char *s2)
 }
 #endif
 
+#define _SURGE_STR(x) #x
+#define SURGE_STR(x) _SURGE_STR(x)
+
 const int namechars = 64;
 const int block_size = 32;
 const int osc_oversampling = 2;

--- a/src/common/gui/CAboutBox.cpp
+++ b/src/common/gui/CAboutBox.cpp
@@ -1,4 +1,5 @@
 #include "CAboutBox.h"
+#include "globals.h"
 #include "resource.h"
 #include <stdio.h>
 
@@ -38,7 +39,8 @@ void CAboutBox::draw(CDrawContext* pContext)
 
       int strHeight = infoFont->getSize(); // There should really be a better API for this in VSTGUI
       std::vector< std::string > msgs = { {
-              std::string( "Version 1.6.0 beta (build: " ) + __DATE__ + " " + __TIME__ + ")",
+              std::string() + "Version " + SURGE_STR(SURGE_VERSION) + " (build: " +
+              __DATE__ + " " + __TIME__ + ")",
               "Released under the GNU General Public License, v3",
               "Copyright 2005-2019 by individual contributors",
               "Source, contributors and other information at https://github.com/kurasu/surge",


### PR DESCRIPTION
Define a macro called SURGE_VERSION in premake5.lua that has the version string from the file VERSION and use this macro in CAboutBox to print the correct version number. Define a macro called STR(x) that stringifies a macro value.

