### PR TITLE
Poly Display Refresh

### DIFF
--- a/src/common/gui/CNumberField.h
+++ b/src/common/gui/CNumberField.h
@@ -172,6 +172,7 @@ public:
          setDirty(true);
       }
    }
+   int getPoly() { return i_poly; }
 
    void setIntMin(int value)
    {

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -213,7 +213,11 @@ void SurgeGUIEditor::idle()
 
       if (polydisp)
       {
-         ((CNumberField*)polydisp)->setPoly(synth->polydisplay);
+         CNumberField *cnpd = static_cast< CNumberField* >( polydisp );
+         int prior = cnpd->getPoly();
+         cnpd->setPoly( synth->polydisplay );
+         if( prior != synth->polydisplay )
+             cnpd->invalid();
       }
 
       if (queue_refresh || synth->refresh_editor)


### PR DESCRIPTION
As reported in #234, the poly display doesn't refresh as you
play. This change makes sure it does, by having the idle
thread call ->invalid() if the value changes.

Note that setPoly already calls setDirty( true ) but it seems the idle thread also needs the invalid call to work; I didn't put that in setPoly but instead - along with all the other invalidations in the idle thread - rechecked the condition and implemented the invalid in idle only. This seems the most symmetric but at some point I do want to understand setDirty( true ) vs invalid.

Comments welcome.