### PR TITLE
Throw SurgeError when configuration.xml is not found

### DIFF
--- a/src/common/SurgeError.cpp
+++ b/src/common/SurgeError.cpp
@@ -1,0 +1,12 @@
+#include "SurgeError.h"
+
+SurgeError::SurgeError(const std::string &message)
+   : message(message)
+{
+}
+
+
+const std::string &SurgeError::getMessage()
+{
+   return message;
+}

--- a/src/common/SurgeError.h
+++ b/src/common/SurgeError.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+class SurgeError {
+public:
+   SurgeError(const std::string &message);
+   SurgeError() = delete;
+
+   const std::string &getMessage();
+
+private:
+   std::string message;
+};

--- a/src/common/SurgeStorage.cpp
+++ b/src/common/SurgeStorage.cpp
@@ -1,8 +1,9 @@
 //-------------------------------------------------------------------------------------------------------
 //	Copyright 2005-2006 Claes Johanson & Vember Audio
 //-------------------------------------------------------------------------------------------------------
-#include "SurgeStorage.h"
 #include "DspUtilities.h"
+#include "SurgeError.h"
+#include "SurgeStorage.h"
 #include <set>
 #include <numeric>
 #include <vt_dsp/vt_dsp_endian.h>
@@ -214,8 +215,7 @@ SurgeStorage::SurgeStorage()
       pDlg = CFUserNotificationCreate(kCFAllocatorDefault, 0, kCFUserNotificationStopAlertLevel,
                                       &nRes, dict);
 #elif __linux__
-      fprintf(stderr, "%s: Unable to load Surge configuration file \"%s\".\n",
-              __func__, snapshotmenupath.c_str());
+      throw SurgeError("configuration.xml was not found from " + snapshotmenupath);
 #else
       MessageBox(::GetActiveWindow(), "Surge is not properly installed. Please reinstall.",
                  "Configuration not found", MB_OK | MB_ICONERROR);


### PR DESCRIPTION
Add a custom exception class SurgeError that is used to fail SurgeStorage constructor when configuration.xml is not found.

Not a perfect fix for #250 but exception is better than a crash for the VST host. 
