### PR TITLE
Polydisplay Doesn't Flicker

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2238,7 +2238,6 @@ void SurgeSynthesizer::process()
    float sceneout alignas(16)[2][2][block_size_os];
    float fxsendout alignas(16)[2][2][block_size];
    bool play_scene[2];
-   polydisplay = 0;
 
    {
       clear_block_antidenormalnoise(sceneout[0][0], block_size_os_quad);
@@ -2296,6 +2295,7 @@ void SurgeSynthesizer::process()
    play_scene[1] = (!voices[1].empty());
 
    int FBentry[2];
+   int vcount = 0;
    for (int s = 0; s < 2; s++)
    {
       FBentry[s] = 0;
@@ -2307,7 +2307,7 @@ void SurgeSynthesizer::process()
          bool resume = v->process_block(FBQ[s][FBentry[s] >> 2], FBentry[s] & 3);
          FBentry[s]++;
 
-         polydisplay++;
+         vcount ++;
 
          if (!resume)
          {
@@ -2320,6 +2320,7 @@ void SurgeSynthesizer::process()
             iter++;
       }
    }
+   polydisplay = vcount;
 
    // CS LEAVE
    storage.CS_ModRouting.leave();

--- a/src/common/SurgeSynthesizer.h
+++ b/src/common/SurgeSynthesizer.h
@@ -11,6 +11,7 @@
 struct QuadFilterChainState;
 
 #include <list>
+#include <atomic>
 using namespace std;
 
 const int max_voices = 64;
@@ -138,7 +139,7 @@ public:
    void prepareModsourceDoProcess(int scenemask);
    unsigned int saveRaw(void** data) override;
    // synth -> editor variables
-   int polydisplay;
+   std::atomic<int> polydisplay; // updated in audio thread, read from ui, so have assignments be atomic
    bool refresh_editor, patch_loaded;
    int learn_param, learn_custom;
    int refresh_ctrl_queue[8];


### PR DESCRIPTION
synth->polydisplay was updated by inplace set to 0 and increment
per voice in the audio thread, then read in idle from the ui thread.
thus the ui thread ocassionaly caught an interim value and flicked.
Change this by
1. make a local voices count and assign to polydisplay once
2. make polydisplay have atomic assignment

fixes issue #248 