### PR TITLE
Retina Bitmaps

### DIFF
--- a/scripts/macOS/package-au.sh
+++ b/scripts/macOS/package-au.sh
@@ -37,7 +37,9 @@ cp -R "$BUNDLE_RES_SRC_LOCATION" "$BUNDLE_DIR/Contents/Resources"
 if [[ -z "$SURGE_USE_VECTOR_SKIN" ]]; then
     cp $BITMAP_SRC_LOCATION/* "$BUNDLE_DIR/Contents/Resources/"
 else
-    rm "$BUNDLE_DIR/Contents/Resources/bmp?????.png"
+    rm "$BUNDLE_DIR/Contents/Resources/bmp*.png"
     cp $VECTOR_BITMAP_SRC_LOCATION/bmp?????.png "$BUNDLE_DIR/Contents/Resources/"
+    mkdir "$BUNDLE_DIR/Contents/Resources/scalable"
+    cp $VECTOR_BITMAP_SRC_LOCATION/*png "$BUNDLE_DIR/Contents/Resources/scalable"
 fi
 

--- a/scripts/macOS/package-vst.sh
+++ b/scripts/macOS/package-vst.sh
@@ -37,7 +37,10 @@ cp -R "$BUNDLE_RES_SRC_LOCATION" "$BUNDLE_DIR/Contents/Resources"
 if [[ -z "$SURGE_USE_VECTOR_SKIN" ]]; then
     cp $BITMAP_SRC_LOCATION/* "$BUNDLE_DIR/Contents/Resources/"
 else
-    rm "$BUNDLE_DIR/Contents/Resources/bmp?????.png"
+    rm "$BUNDLE_DIR/Contents/Resources/bmp*.png"
     cp $VECTOR_BITMAP_SRC_LOCATION/bmp?????.png "$BUNDLE_DIR/Contents/Resources/"
+    mkdir "$BUNDLE_DIR/Contents/Resources/scalable"
+    cp $VECTOR_BITMAP_SRC_LOCATION/*png "$BUNDLE_DIR/Contents/Resources/scalable"
 fi
+
 

--- a/scripts/macOS/package-vst3.sh
+++ b/scripts/macOS/package-vst3.sh
@@ -37,7 +37,9 @@ cp -R "$BUNDLE_RES_SRC_LOCATION" "$BUNDLE_DIR/Contents/Resources"
 if [[ -z "$SURGE_USE_VECTOR_SKIN" ]]; then
     cp $BITMAP_SRC_LOCATION/* "$BUNDLE_DIR/Contents/Resources/"
 else
-    rm "$BUNDLE_DIR/Contents/Resources/bmp?????.png"
+    rm "$BUNDLE_DIR/Contents/Resources/bmp*.png"
     cp $VECTOR_BITMAP_SRC_LOCATION/bmp?????.png "$BUNDLE_DIR/Contents/Resources/"
+    mkdir "$BUNDLE_DIR/Contents/Resources/scalable"
+    cp $VECTOR_BITMAP_SRC_LOCATION/*png "$BUNDLE_DIR/Contents/Resources/scalable"
 fi
 

--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -1,0 +1,63 @@
+#include "CScalableBitmap.h"
+#if MAC
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
+CScalableBitmap::CScalableBitmap( CResourceDescription desc ) : CBitmap( desc )
+{
+    int id = 0;
+    if( desc.type == CResourceDescription::kIntegerType )
+        id = (int32_t)desc.u.id;
+    
+    scales = {{ 100, 200 }};
+    scaleFilePostfixes[ 100 ] = "";
+    scaleFilePostfixes[ 200 ] = "@2x";
+
+    //fprintf( stderr, "\n" );
+    for( auto sc : scales )
+    {
+        auto postfix = scaleFilePostfixes[ sc ];
+        char filename [PATH_MAX];
+        sprintf (filename, "scalable/bmp%05d%s.png", id, postfix.c_str() );
+            
+        CBitmap *tmp = new CBitmap( CResourceDescription( filename ) );
+        //fprintf( stderr, "%s, Scale=%d, Dim=(%lf x %lf)\n", filename, sc, tmp->getWidth(), tmp->getHeight() );
+
+        if( tmp->getWidth() > 0 )
+        {
+            scaledBitmaps[ sc ] = tmp;
+        }
+        else
+        {
+            scaledBitmaps[ sc ] = NULL;
+        }
+        
+    }
+}
+
+void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoint& offset, float alpha )
+{
+    /*
+    ** For now this is a fixed 'retina' style draw of using 2x bitmaps at 0.5 scale if they exist
+    */
+    if( scaledBitmaps[ 200 ] != NULL )
+    {
+        CGraphicsTransform tf = CGraphicsTransform().scale( 0.5, 0.5 );
+        CGraphicsTransform invtf = tf.inverse();
+        
+        CDrawContext::Transform tr( *context, tf );
+
+        // Have to de-const these to do the transform alas
+        CRect ncrect = rect;
+        CRect nr = invtf.transform( ncrect );
+
+        CPoint ncoff = offset;
+        CPoint no = invtf.transform( ncoff );
+        
+        scaledBitmaps[ 200 ]->draw( context, nr, no, alpha );
+    }
+    else
+    {
+        CBitmap::draw( context, rect, offset, alpha );
+    }
+}

--- a/src/common/gui/CScalableBitmap.cpp
+++ b/src/common/gui/CScalableBitmap.cpp
@@ -3,33 +3,40 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
-CScalableBitmap::CScalableBitmap( CResourceDescription desc ) : CBitmap( desc )
+CScalableBitmap::CScalableBitmap(CResourceDescription desc) : CBitmap(desc)
 {
     int id = 0;
-    if( desc.type == CResourceDescription::kIntegerType )
+    if(desc.type == CResourceDescription::kIntegerType)
         id = (int32_t)desc.u.id;
-    
+
+    /*
+    ** At this stage this scales array may seem like overkill since it only has two
+    ** values. But to impelemnt scalability we will end up with multiple sizes, including
+    ** 1.5x maybe 1.25x and so on. So build the architecture now to support that even
+    ** though we only populate with two types. And since our sizes will include a 1.25x
+    ** hash on integer percentages (so 100 -> 1x), not on floats.
+    */
+
     scales = {{ 100, 200 }};
     scaleFilePostfixes[ 100 ] = "";
     scaleFilePostfixes[ 200 ] = "@2x";
 
-    //fprintf( stderr, "\n" );
-    for( auto sc : scales )
+    for(auto sc : scales)
     {
-        auto postfix = scaleFilePostfixes[ sc ];
-        char filename [PATH_MAX];
-        sprintf (filename, "scalable/bmp%05d%s.png", id, postfix.c_str() );
-            
-        CBitmap *tmp = new CBitmap( CResourceDescription( filename ) );
-        //fprintf( stderr, "%s, Scale=%d, Dim=(%lf x %lf)\n", filename, sc, tmp->getWidth(), tmp->getHeight() );
+        auto postfix = scaleFilePostfixes[sc];
 
-        if( tmp->getWidth() > 0 )
+        char filename [PATH_MAX];
+        sprintf (filename, "scalable/bmp%05d%s.png", id, postfix.c_str());
+            
+        CBitmap *tmp = new CBitmap(CResourceDescription( filename ));
+
+        if(tmp->getWidth() > 0)
         {
-            scaledBitmaps[ sc ] = tmp;
+            scaledBitmaps[sc] = tmp;
         }
         else
         {
-            scaledBitmaps[ sc ] = NULL;
+            scaledBitmaps[sc] = NULL;
         }
         
     }
@@ -40,24 +47,24 @@ void CScalableBitmap::draw (CDrawContext* context, const CRect& rect, const CPoi
     /*
     ** For now this is a fixed 'retina' style draw of using 2x bitmaps at 0.5 scale if they exist
     */
-    if( scaledBitmaps[ 200 ] != NULL )
+    if (scaledBitmaps[ 200 ] != NULL)
     {
         CGraphicsTransform tf = CGraphicsTransform().scale( 0.5, 0.5 );
         CGraphicsTransform invtf = tf.inverse();
         
-        CDrawContext::Transform tr( *context, tf );
+        CDrawContext::Transform tr(*context, tf);
 
         // Have to de-const these to do the transform alas
         CRect ncrect = rect;
-        CRect nr = invtf.transform( ncrect );
+        CRect nr = invtf.transform(ncrect);
 
         CPoint ncoff = offset;
-        CPoint no = invtf.transform( ncoff );
+        CPoint no = invtf.transform(ncoff);
         
-        scaledBitmaps[ 200 ]->draw( context, nr, no, alpha );
+        scaledBitmaps[ 200 ]->draw(context, nr, no, alpha);
     }
     else
     {
-        CBitmap::draw( context, rect, offset, alpha );
+        CBitmap::draw(context, rect, offset, alpha);
     }
 }

--- a/src/common/gui/CScalableBitmap.h
+++ b/src/common/gui/CScalableBitmap.h
@@ -1,0 +1,21 @@
+/*
+** CScalableBitmap is an implmentation of VSGTUI::CBitmap which can 
+** load bitmaps at multiple resolutions and draw them scaled accordingly
+*/
+
+#include <vstgui/vstgui.h>
+
+#include <vector>
+#include <map>
+
+class CScalableBitmap : public VSTGUI::CBitmap
+{
+public:
+    CScalableBitmap( CResourceDescription d );
+
+    std::vector< int > scales;  // 100, 150, 200, 300 etc... - int percentages
+    std::map< int, VSTGUI::CBitmap * > scaledBitmaps;
+    std::map< int, std::string > scaleFilePostfixes;
+
+    virtual void draw (CDrawContext* context, const CRect& rect, const CPoint& offset, float alpha);
+};

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -1,6 +1,14 @@
 #include "SurgeBitmaps.h"
 #include <map>
 
+#if MAC && TARGET_AUDIOUNIT // for now
+#define USE_SCALABLE_BITMAPS 1
+#endif
+
+#ifdef USE_SCALABLE_BITMAPS
+#include "CScalableBitmap.h"
+#endif
+
 std::map<int, VSTGUI::CBitmap*> bitmap_registry;
 
 static std::atomic_int refCount(0);
@@ -13,7 +21,7 @@ SurgeBitmaps::SurgeBitmaps()
       addEntry(IDB_BUTTON_ABOUT);
       addEntry(IDB_ABOUT);
       addEntry(IDB_FILTERBUTTONS);
-      addEntry(IDB_OSCSWITCH);
+      addEntry(IDB_OSCSWITCH); 
       addEntry(IDB_FILTERSUBTYPE);
       addEntry(IDB_RELATIVE_TOGGLE);
       addEntry(IDB_OSCSELECT);
@@ -72,7 +80,11 @@ void SurgeBitmaps::addEntry(int id)
 {
    assert(bitmap_registry.find(id) == bitmap_registry.end());
 
+#ifdef USE_SCALABLE_BITMAPS
+   VSTGUI::CBitmap *bitmap = new CScalableBitmap(CResourceDescription(id));
+#else
    VSTGUI::CBitmap* bitmap = new VSTGUI::CBitmap(CResourceDescription(id));
+#endif
    bitmap_registry[id] = bitmap;
 }
 

--- a/src/common/gui/SurgeBitmaps.cpp
+++ b/src/common/gui/SurgeBitmaps.cpp
@@ -1,7 +1,7 @@
 #include "SurgeBitmaps.h"
 #include <map>
 
-#if MAC && TARGET_AUDIOUNIT // for now
+#if MAC  
 #define USE_SCALABLE_BITMAPS 1
 #endif
 


### PR DESCRIPTION
@kurasu and others - I would really appreciate a review of this. While it works, I made design choices you may not like, so please take a look. I will not sweep it without a positive ack from @kurasu. 

And note that in default configuration this does nothing.

If scalable bitmaps are present we can begin to implement zoom.
Step one is to implement Mac Retina display. We do that here
by loading 2x bitmaps if available and drawing them at 0.5x
scale. On retina displays this looks great. On regular displays
it is a no-op basically. See #226 for more.

None of this is activated if the skins aren't installed and
by default it falls back to the standard bitmaps.