### PR TITLE
Fix VST2 and AU Learned Automation

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2356,4 +2356,9 @@ void SurgeGUIEditor::zoomInDir(int dir)
    zoom_callback(this);
 }
 
+long SurgeGUIEditor::applyParameterOffset(long id)
+{
+    return id-start_paramtags;
+}
+
 //------------------------------------------------------------------------------------------------

--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -2220,7 +2220,6 @@ void SurgeGUIEditor::valueChanged(CControl* control)
 
 void SurgeGUIEditor::beginEdit(long index)
 {
-#if !AU
    if (index < start_paramtags)
    {
       return;
@@ -2232,14 +2231,12 @@ void SurgeGUIEditor::beginEdit(long index)
    {
       super::beginEdit(externalparam);
    }
-#endif
 }
 
 //------------------------------------------------------------------------------------------------
 
 void SurgeGUIEditor::endEdit(long index)
 {
-#if !AU
    if (index < start_paramtags)
    {
       return;
@@ -2251,14 +2248,13 @@ void SurgeGUIEditor::endEdit(long index)
    {
       super::endEdit(externalparam);
    }
-#endif
 }
 
 //------------------------------------------------------------------------------------------------
 
 void SurgeGUIEditor::controlBeginEdit(VSTGUI::CControl* control)
 {
-#if AU
+#if TARGET_AUDIOUNIT
    long tag = control->getTag();
    int ptag = tag - start_paramtags;
    if ((ptag >= 0) && (ptag < synth->storage.getPatch().param_ptr.size()))
@@ -2266,7 +2262,7 @@ void SurgeGUIEditor::controlBeginEdit(VSTGUI::CControl* control)
       int externalparam = synth->remapInternalToExternalApiId(ptag);
       if (externalparam >= 0)
       {
-         ((aulayer*)synth->parent)->ParameterBeginEdit(externalparam);
+          synth->getParent()->ParameterBeginEdit(externalparam);
       }
    }
 #endif
@@ -2276,7 +2272,7 @@ void SurgeGUIEditor::controlBeginEdit(VSTGUI::CControl* control)
 
 void SurgeGUIEditor::controlEndEdit(VSTGUI::CControl* control)
 {
-#if AU
+#if TARGET_AUDIOUNIT
    long tag = control->getTag();
    int ptag = tag - start_paramtags;
    if ((ptag >= 0) && (ptag < synth->storage.getPatch().param_ptr.size()))
@@ -2284,7 +2280,7 @@ void SurgeGUIEditor::controlEndEdit(VSTGUI::CControl* control)
       int externalparam = synth->remapInternalToExternalApiId(ptag);
       if (externalparam >= 0)
       {
-         ((aulayer*)synth->parent)->ParameterEndEdit(externalparam);
+         synth->getParent()->ParameterEndEdit(externalparam);
       }
    }
 #endif

--- a/src/common/gui/SurgeGUIEditor.h
+++ b/src/common/gui/SurgeGUIEditor.h
@@ -45,6 +45,8 @@ public:
    virtual void beginEdit(long index);
    virtual void endEdit(long index);
 
+   virtual long applyParameterOffset(long index);
+   
 #if !TARGET_VST3
    bool open(void* parent) override;
 #else

--- a/src/vst2/Vst2PluginInstance.cpp
+++ b/src/vst2/Vst2PluginInstance.cpp
@@ -543,3 +543,15 @@ VstInt32 Vst2PluginInstance::setChunk(void* data, VstInt32 byteSize, bool isPres
 
    return 1;
 }
+
+
+
+bool Vst2PluginInstance::beginEdit( VstInt32 index )
+{
+    return AudioEffectX::beginEdit( ((SurgeGUIEditor *)editor)->applyParameterOffset( _instance->remapExternalApiToInternalId(index ) ) );
+}
+
+bool Vst2PluginInstance::endEdit( VstInt32 index )
+{
+    return AudioEffectX::endEdit( ((SurgeGUIEditor *)editor)->applyParameterOffset( _instance->remapExternalApiToInternalId(index)));
+}

--- a/src/vst2/Vst2PluginInstance.h
+++ b/src/vst2/Vst2PluginInstance.h
@@ -69,6 +69,9 @@ public:
    virtual VstInt32 getChunk(void** data, bool isPreset = false);
    virtual VstInt32 setChunk(void* data, VstInt32 byteSize, bool isPreset = false);
 
+   virtual bool beginEdit( VstInt32 index );
+   virtual bool endEdit( VstInt32 index );
+   
    virtual VstInt32 getNumMidiInputChannels()
    {
       return 3;


### PR DESCRIPTION
@kurasu very interested in your comments on this diff also. See #247 for the problem. This solution seems the smallest one.

This diff fixes automation in VST2 in Live, Bitwig, Reason etc...
The basic problem is that the display control ids differ from the logical
control ids. The synth remap does logical remapping but the display
remapping - which is implemented by "- start_paramtag" or "+ start_paramtag"
in the code doesn't flow to events uniformly. Specifically it didn't
flow to beginEdit and endEdit in VST2. So expose that "-" operation as
a well named function, override begin and end edit in vst2 host,
and voila.

We will definitely need to do the same with vst3 and au somehow.
Still figuring out those codepaths though.