### PR TITLE
Contoller -> Controller

### DIFF
--- a/src/common/gui/SurgeGUIEditor.cpp
+++ b/src/common/gui/SurgeGUIEditor.cpp
@@ -1551,7 +1551,7 @@ int32_t SurgeGUIEditor::controlModifierClicked(CControl* control, CButtonState b
                  currentSub->addEntry( cmd );
                  
              }
-             contextMenu->addEntry( midiSub, "Set Contoller To..." );
+             contextMenu->addEntry( midiSub, "Set Controller To..." );
              
          }
 


### PR DESCRIPTION
this PR fixes the typo `Set Contoller to...` to `Set Controller to...`

![set contoller to](https://user-images.githubusercontent.com/4966687/51050596-fe4c2380-15d9-11e9-9959-bad911558a5c.gif)

fixes #264 
