### PR TITLE
VST2: Fail safely

### DIFF
--- a/src/vst2/Vst2PluginInstance.h
+++ b/src/vst2/Vst2PluginInstance.h
@@ -88,15 +88,21 @@ protected:
    int blockpos;
 
 public:
+   enum State {
+      UNINITIALIZED  = 0,
+      INITIALIZED    = 1,
+      DEAD           = 2,
+   };
+
    SurgeSynthesizer* _instance;
    VstEvent* _eventptr[MAX_EVENTS];
    char _eventbufferdata[EVENTBUFFER_SIZE];
-
    int events_this_block, events_processed;
-   bool initialized;
-   void init();
+   enum State state;
    char programName[32];
    bool plug_is_synth;
    int input_connected;
    FpuState _fpuState;
+
+   bool tryInit();
 };


### PR DESCRIPTION
If initialization fails, do not try to reinitialize Surge. Free the
synth instance when initialization fails. These were the two root causes
that caused Renoise on Linux to eat all memory and stall the whole DAW.
Now the plugin crashes but Renoise stays alive.

With this commit we can really start fix Linux issues with a nice
edit-compiler-run cycle and do not have to wait for 2-5 minutes for
Renoise to finally crash, and have laptop freezed while waiting.

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>