### PR TITLE
string typo fix: file already exist -> file already exists

### DIFF
--- a/src/common/SurgeSynthesizerIO.cpp
+++ b/src/common/SurgeSynthesizerIO.cpp
@@ -183,14 +183,14 @@ bool askIfShouldOverwrite()
    CFOptionFlags responseFlags;
    CFUserNotificationDisplayAlert(0, kCFUserNotificationPlainAlertLevel, 0, 0, 0,
                                   CFSTR("Overwrite?"),
-                                  CFSTR("The file already exist, do you wish to overwrite it?"),
+                                  CFSTR("The file already exists, do you wish to overwrite it?"),
                                   CFSTR("Yes"), CFSTR("No"), 0, &responseFlags);
    if ((responseFlags & 0x3) != kCFUserNotificationDefaultResponse)
       return false;
 #elif __linux__
    printf("Implement me\n");
 #else
-   if (MessageBox(::GetActiveWindow(), "The file already exist, do you wish to overwrite it?",
+   if (MessageBox(::GetActiveWindow(), "The file already exists, do you wish to overwrite it?",
                   "Overwrite?", MB_YESNO | MB_ICONQUESTION) != IDYES)
       return false;
 #endif


### PR DESCRIPTION
minor typo fix:
<img width="400" alt="screenshot_11_01_2019__22_42" src="https://user-images.githubusercontent.com/4966687/51058716-5a22a680-15f2-11e9-8c87-2ab7b5c5b27e.png">

`The file already exist` sounds better as `The file already exists`.
