### PR TITLE
Make sure you null terminate

### DIFF
--- a/src/mac/cocoa_utils.mm
+++ b/src/mac/cocoa_utils.mm
@@ -27,6 +27,7 @@ void CocoaUtils::miniedit_text_impl( char *c, int maxchars )
         
         if (response == NSAlertFirstButtonReturn) {
             strncpy( c, [[txt stringValue] UTF8String], maxchars );
+            c[maxchars - 1] = 0;
         }
     }
 }


### PR DESCRIPTION
You copy up to N chars. If the UI runs long that last one won't
be \0. So force it to be. This addresses the "extra -" in 267.