### PR TITLE
Fix mac crash on subdirs

### DIFF
--- a/libs/filesystem/filesystem.cpp
+++ b/libs/filesystem/filesystem.cpp
@@ -46,6 +46,9 @@ namespace std::experimental::filesystem {
     
     path path::extension() {
         auto idx = this->p.find_last_of(".");
+        if( idx == std::string::npos )
+            return path( "" );
+
         path res(p.substr(idx));
         return res;
     }


### PR DESCRIPTION
file::extension on a file or path with no extension behaved
improperly. Correct it. Stops crash at startup with subdirs.
Fixes issue #283 