### PR TITLE
More mac build and installer

### DIFF
--- a/build-osx.sh
+++ b/build-osx.sh
@@ -37,6 +37,10 @@ Commands are:
         --build-and-install      Build and install the assets
         --build-validate-au      Build and install the audio unit then validate it
 
+        --package                Creates a .pkg file from current built state in products
+        --clean-and-package      Cleans everything; runs all the builds; makes an installer; drops it in products
+                                 Equivalent of running --clean-all then --build then --package
+
         --clean                  Clean all the builds
         --clean-all              Clean all the builds and remove the xcode files and target directories
 
@@ -231,6 +235,25 @@ run_uninstall_surge()
     sudo rm -rf ~/Library/Application\ Support/Surge
 }
 
+run_package()
+{
+    pkgver=`cat VERSION`beta-`(date +%Y-%m-%d-%H%M)`
+    echo "Building with version [${pkgver}]"
+    cd installer_mac/
+    ./make_installer.sh ${pkgver}
+    cd ..
+
+    mv installer_mac/installer/*${pkgver}*.pkg products/
+
+    echo
+    echo "Package completed and in products/ directory"
+    echo
+    ls -l products/*${pkgver}*.pkg
+    echo
+    echo "Have a lovely day!"
+    echo
+}
+
 # This is the main section of the script
 command="$1"
 
@@ -271,6 +294,14 @@ case $command in
         ;;
     --clean-all)
         run_clean_all
+        ;;
+    --clean-and-package)
+        run_clean_all
+        run_all_builds
+        run_package
+        ;;
+    --package)
+        run_package
         ;;
     --uninstall-surge)
         run_uninstall_surge

--- a/installer_mac/ResourcesPackageScript/postinstall
+++ b/installer_mac/ResourcesPackageScript/postinstall
@@ -1,4 +1,4 @@
 #!/bin/bash
-cp -R "$DSTVOLUME/tmp/Surge" /Library/Application\ Support/
+rsync -r --delete "$DSTVOLUME/tmp/Surge" /Library/Application\ Support/
 chown -R $USER:staff /Library/Application\ Support/Surge
 rm -rf "$DSTVOLUME/tmp/Surge"

--- a/installer_mac/make_installer.sh
+++ b/installer_mac/make_installer.sh
@@ -90,9 +90,7 @@ echo "Commit: $(git rev-parse HEAD)" >> "$RSRCS/BuildInfo.txt"
 
 # build resources package
 
-pkgbuild --analyze --root "$RSRCS" Surge_Resources.plist
-pkgbuild --root "$RSRCS" --component-plist Surge_Resources.plist --identifier "com.vemberaudio.resources.pkg" --version $VERSION --scripts ResourcesPackageScript --install-location "/tmp/Surge" Surge_Resources.pkg
-rm Surge_Resources.plist
+pkgbuild --root "$RSRCS" --identifier "com.vemberaudio.resources.pkg" --version $VERSION --scripts ResourcesPackageScript --install-location "/tmp/Surge" Surge_Resources.pkg
 
 # remove build info from resource folder
 


### PR DESCRIPTION
These diffs fix the fact that resources didn't overwrite bu
1. Not doing the analyze to get update correct
2. Fixing the postinstall script to rsync --delete

Additionally it adds packaging options to build-osx to make
these features easier to use.

Finally the README was a little long in the tooth now that
we have mac more streamlined, so update it.